### PR TITLE
Add Debian and make update call more robust

### DIFF
--- a/snmp/os-updates.sh
+++ b/snmp/os-updates.sh
@@ -12,8 +12,9 @@ BIN_ZYPPER='/usr/bin/zypper'
 CMD_ZYPPER='lu'
 BIN_YUM='/usr/bin/yum'
 CMD_YUM='check-update'
-BIN_APT='/usr/bin/apt'
-CMD_APT='list --upgradable'
+BIN_APT='/usr/bin/apt-get'
+CMD_APT='-s upgrade'
+CMD_UPDATE='-qq update'
 
 #general check for os based on /etc/os-release
 if [ -f /etc/os-release ]; then
@@ -32,10 +33,11 @@ if [ -f /etc/os-release ]; then
 		else
 			echo "0";
 		fi
-	elif [ $OS == "ubuntu" ]; then
-		UPDATES=`$BIN_APT $CMD_APT | $BIN_WC $CMD_WC`
+	elif [ $OS == "ubuntu" ] || [ $OS == "debian" ]; then
+		`$BIN_APT $CMD_UPDATE`
+		UPDATES=`$BIN_APT $CMD_APT | grep 'Inst' | $BIN_WC $CMD_WC`
 		if [ $UPDATES -gt 1 ]; then
-			echo $(($UPDATES-1));
+			echo $UPDATES;
 		else
 			echo "0";
 		fi

--- a/snmp/os-updates.sh
+++ b/snmp/os-updates.sh
@@ -14,7 +14,6 @@ BIN_YUM='/usr/bin/yum'
 CMD_YUM='check-update'
 BIN_APT='/usr/bin/apt-get'
 CMD_APT='-s upgrade'
-CMD_UPDATE='-qq update'
 
 #general check for os based on /etc/os-release
 if [ -f /etc/os-release ]; then
@@ -34,7 +33,6 @@ if [ -f /etc/os-release ]; then
 			echo "0";
 		fi
 	elif [ $OS == "ubuntu" ] || [ $OS == "debian" ]; then
-		`$BIN_APT $CMD_UPDATE`
 		UPDATES=`$BIN_APT $CMD_APT | grep 'Inst' | $BIN_WC $CMD_WC`
 		if [ $UPDATES -gt 1 ]; then
 			echo $UPDATES;


### PR DESCRIPTION
- Debian based systems need to update the index before being able to report upgradable packages.
- Debian old-stable doesn't have `apt` yet and Ubuntu 14.04 emits the following warning when using `apt` in a script:
`WARNING: /usr/bin/apt does not have a stable CLI interface yet. Use with caution in scripts.`

By using `apt-get`, issuing a `update` call first and then counting the result of `grep 'Inst'`, this script now works on Debian 7, Debian 8, Ubuntu 14.04 and Ubuntu 16.04.