### PR TITLE
app: ntp-server 

### DIFF
--- a/snmp/ntp-server.sh
+++ b/snmp/ntp-server.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+################################################################
+# copy this script to somewhere like /opt and make chmod +x it #
+# edit your snmpd.conf and include                             #
+# extend ntpdserver /opt/ntp-server.sh                         #
+# restart snmpd and activate the app for desired host          #
+# please make sure you have the path/binaries below            #
+################################################################
+# Binaries and paths required                                  #
+################################################################ 
+BIN_NTPQ='/usr/sbin/ntpq'
+BIN_GREP='/usr/bin/grep'
+BIN_TR='/usr/bin/tr'
+BIN_CUT='/usr/bin/cut'
+BIN_SED='/usr/bin/sed'
+################################################################
+# Don't change anything unless you know what are you doing     #
+################################################################
+CMD0=`$BIN_NTPQ -c rv | $BIN_GREP -Eow "stratum=[0-9]" | $BIN_CUT -d "=" -f 2`
+echo $CMD0
+
+CMD1=`$BIN_NTPQ -c rv | $BIN_GREP 'jitter' | $BIN_TR '\n' ' '`
+IFS=', ' read -r -a array <<< "$CMD1"
+
+for value in 2 3 4 5 6
+do
+	echo ${array["$value"]} | $BIN_CUT -d "=" -f 2
+done
+
+CMD2=`$BIN_NTPQ -c iostats localhost | $BIN_TR -d ' ' | $BIN_TR '\n' ','`
+IFS=',' read -r -a array <<< "$CMD2"
+
+for value in 0 1 2 3 5 6 7 8
+do
+    echo ${array["$value"]} | $BIN_SED -e 's/[^0-9]/ /g' -e 's/^ *//g' -e 's/ *$//g'
+done

--- a/snmp/ntp-server.sh
+++ b/snmp/ntp-server.sh
@@ -2,7 +2,7 @@
 ################################################################
 # copy this script to somewhere like /opt and make chmod +x it #
 # edit your snmpd.conf and include                             #
-# extend ntpdserver /opt/ntp-server.sh                         #
+# extend ntp-server /opt/ntp-server.sh                         #
 # restart snmpd and activate the app for desired host          #
 # please make sure you have the path/binaries below            #
 ################################################################

--- a/snmp/ntp-server.sh
+++ b/snmp/ntp-server.sh
@@ -16,7 +16,7 @@ BIN_SED='/usr/bin/sed'
 ################################################################
 # Don't change anything unless you know what are you doing     #
 ################################################################
-CMD0=`$BIN_NTPQ -c rv | $BIN_GREP -Eow "stratum=[0-9]" | $BIN_CUT -d "=" -f 2`
+CMD0=`$BIN_NTPQ -c rv | $BIN_GREP -Eow "stratum=[0-9]+" | $BIN_CUT -d "=" -f 2`
 echo $CMD0
 
 CMD1=`$BIN_NTPQ -c rv | $BIN_GREP 'jitter' | $BIN_TR '\n' ' '`


### PR DESCRIPTION
rewrite the snmp script for ntp-server:
- no more php need on the host
- no more need for ntpdc
- drop-in replacement for old php script
- provides data for newer output versions of ntpq
- tested with ntpq 4.2.8p8