### PR TITLE
Update hddtemp to include hddtemp -w option

### DIFF
--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -19,7 +19,7 @@ hddtemp=`which hddtemp 2>/dev/null`
 
 if [ "${hddtemp}" != "" ]; then
 	if [ -x "${hddtemp}" ]; then
-		content=`${hddtemp} -q ${disks} 2>/dev/null | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/°/\|/g';`
+		content=`${hddtemp} -w -q ${disks} 2>/dev/null | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/°/\|/g';`
 		if [ "${content}" != "" ]; then
 			echo '<<<hddtemp>>>'
 			echo ${content}


### PR DESCRIPTION
hddtemp gives inconsistent values in it's current state, after some debugging I was able to resolve the issue by passing -w to the hddtemp command, this will wake-up the drive if it is in a sleep state to gather information.