### PR TITLE
Fix ceph bug

### DIFF
--- a/agent-local/ceph
+++ b/agent-local/ceph
@@ -18,7 +18,7 @@ from subprocess import check_output
 import json
 
 def cephdf():
-    cephdf    = check_output(["/usr/bin/ceph", "-f", "json", "df"])
+    cephdf    = check_output(["/usr/bin/ceph", "-f", "json", "df"]).replace('-inf', '0')
 
     s = json.loads(cephdf)
     print("c:%i:%i:%i" % (s['stats']['total_bytes'], s['stats']['total_used_bytes'], s['stats']['total_avail_bytes']))
@@ -31,13 +31,13 @@ def cephdf():
 
 
 def osdperf():
-    osdperf   = check_output(["/usr/bin/ceph", "-f", "json", "osd", "perf"])
+    osdperf   = check_output(["/usr/bin/ceph", "-f", "json", "osd", "perf"]).replace('-inf', '0')
 
     for o in json.loads(osdperf)['osd_perf_infos']:
         print("osd.%s:%i:%i" % (o['id'], o['perf_stats']['apply_latency_ms'], o['perf_stats']['commit_latency_ms']))
 
 def poolstats():
-    poolstats = check_output(["/usr/bin/ceph", "-f", "json", "osd", "pool", "stats"])
+    poolstats = check_output(["/usr/bin/ceph", "-f", "json", "osd", "pool", "stats"]).replace('-inf', '0')
 
     for p in json.loads(poolstats):
         try: 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+librenms-agent (1.0.6) stable; urgency=low
+
+  - Fix a dirty hack to prevent failing of stats when the cluster is rebuilding
+    because Ceph returns '-inf' which the json decompiler doesn't seem to get..
+
+ -- Mark Schouten <mark@tuxis.nl> Tue, 22 Mar 2016 00:27:00 +0200
+
+librenms-agent (1.0.5) stable; urgency=low
+
+  - Include a PowerDNS Authoritative agent
+
+ -- Mark Schouten <mark@tuxis.nl> Mon, 23 Nov 2015 14:10:00 +0200
+
 librenms-agent (1.0.4) stable; urgency=low
 
   - Include a Ceph agent


### PR DESCRIPTION
Ceph did not work when the cluster was fixing itself. It seems that Ceph is returning json that Python does not understand. This 'works around' that issue.

Also bumps the debian version to 1.0.6