### PR TITLE
Make ups-nut work on Debian Jessie

### DIFF
--- a/snmp/ups-nut.sh
+++ b/snmp/ups-nut.sh
@@ -9,7 +9,7 @@
 # 4. restart snmpd on the host                                 #
 # 5. activate the app for the desired host in LibreNMS         #
 ################################################################
-UPS_NAME='apc'
+UPS_NAME='APCUPS'
 
 PATH=$PATH:/usr/bin:/bin
 TMP=$(upsc $UPS_NAME 2>/dev/null)

--- a/snmp/ups-nut.sh
+++ b/snmp/ups-nut.sh
@@ -1,29 +1,22 @@
 #!/usr/bin/env bash
 ################################################################
-# copy this script to /etc/snmp/ and make it executable:       #
-# chmod +x ups-nut.sh                                          #
-# ------------------------------------------------------------ #
-# edit your snmpd.conf and include:                            #
-# extend ups-nut /etc/snmp/ups-nut.sh                          #
-#--------------------------------------------------------------#
-# restart snmpd and activate the app for desired host          #
-#--------------------------------------------------------------#
-# please make sure you have the path/binaries below            #
+# Instructions:                                                #
+# 1. copy this script to /etc/snmp/ and make it executable:    #
+#    chmod +x ups-nut.sh                                       #
+# 2. make sure UPS_NAME below matches the name of your UPS     #
+# 3. edit your snmpd.conf to include this line:                #
+#    extend ups-nut /etc/snmp/ups-nut.sh                       #
+# 4. restart snmpd on the host                                 #
+# 5. activate the app for the desired host in LibreNMS         #
 ################################################################
-BIN_UPSC='/usr/bin/upsc'
-UPSC_CMD='APCUPS'
-BIN_CAT='/usr/bin/cat'
-BIN_GREP='/usr/bin/grep'
-BIN_TR='/usr/bin/tr'
-BIN_CUT='/usr/bin/cut'
-################################################################
-# Don't change anything unless you know what are you doing     #
-################################################################
-TMP=`$BIN_UPSC $UPSC_CMD 2>/dev/null`
+UPS_NAME='apc'
 
-for value in "battery.charge:[0-9]+" "battery.low:[0-9]+" "battery.runtime:[0-9]+" "battery.voltage:[0-9.]+" "battery.voltage.nominal:[0-9]+" "input.voltage.nominal:[0-9.]+" "input.voltage:[0-9.]+" "ups.load:[0-9]+"
+PATH=$PATH:/usr/bin:/bin
+TMP=$(upsc $UPS_NAME 2>/dev/null)
+
+for value in "battery\.charge: [0-9.]+" "battery\.(runtime\.)?low: [0-9]+" "battery\.runtime: [0-9]+" "battery\.voltage: [0-9.]+" "battery\.voltage\.nominal: [0-9]+" "input\.voltage\.nominal: [0-9.]+" "input\.voltage: [0-9.]+" "ups\.load: [0-9.]+"
 do
-	OUT=`echo "$TMP" | $BIN_TR -d ' ' | $BIN_GREP -Eow $value | $BIN_CUT -d ":" -f 2`
+	OUT=$(echo $TMP | grep -Eo "$value" | awk '{print $2}' | LANG=C sort | head -n 1)
 	if [ -n "$OUT" ]; then
 		echo $OUT
 	else


### PR DESCRIPTION
This script was broken on Debian Jessie (and probably all Debian-based distros, including Ubuntu). This commit removes the hard-coding of paths and uses $PATH per normal bash practice, and should work on a wider range of shell variants (possibly even ash or dash).

I also found that my UPS does not have battery.low defined, but instead has battery.runtime.low, which I hope is the same thing. (A couple of quick web searches did not indicate one way or the other.)