### PR TITLE
added fedora support

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -16,7 +16,10 @@ elif [ "${OS}" = "AIX" ] ; then
 elif [ "${OS}" = "Linux" ] ; then
   KERNEL=`uname -r`
 
-  if [ -f /etc/redhat-release ] ; then
+  if [ -f /etc/fedora-release ]; then
+    DIST=$(cat /etc/fedora-release)
+        
+  elif [ -f /etc/redhat-release ] ; then
     DIST=$(cat /etc/redhat-release | awk '{print $1}')
     if [ "${DIST}" = "CentOS" ]; then
       DIST="CentOS"


### PR DESCRIPTION
Added support for detecting Fedora. As Fedora has an /etc/redhat-release, I added the check for /etc/fedora-release before /etc/redhat-release.