### PR TITLE
Added fedora support to distro/os-updates

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -16,7 +16,11 @@ elif [ "${OS}" = "AIX" ] ; then
 elif [ "${OS}" = "Linux" ] ; then
   KERNEL=`uname -r`
 
-  if [ -f /etc/redhat-release ] ; then
+  if [ -f /etc/fedora-release ]; then
+    DIST=$(cat /etc/fedora-release | awk '{print $1}')
+    REV=`cat /etc/fedora-release | sed s/.*release\ // | sed s/\ .*//`
+        
+  elif [ -f /etc/redhat-release ] ; then
     DIST=$(cat /etc/redhat-release | awk '{print $1}')
     if [ "${DIST}" = "CentOS" ]; then
       DIST="CentOS"

--- a/snmp/os-updates.sh
+++ b/snmp/os-updates.sh
@@ -18,6 +18,8 @@ BIN_ZYPPER='/usr/bin/zypper'
 CMD_ZYPPER='lu'
 BIN_YUM='/usr/bin/yum'
 CMD_YUM='-q check-update'
+BIN_DNF='/usr/bin/dnf'
+CMD_DNF='-q check-update'
 BIN_APT='/usr/bin/apt-get'
 CMD_APT='-qq -s upgrade'
 BIN_PACMAN='/usr/bin/pacman'
@@ -40,6 +42,13 @@ if [ -f /etc/os-release ]; then
 		if [ $UPDATES -gt 6 ]; then
 			echo $(($UPDATES-6));
 		else
+			echo "0";
+		fi
+	elif [ $OS == "fedora" ]; then
+		UPDATES=`$BIN_DNF $CMD_DNF | $BIN_WC $CMD_WC`
+		if [ $UPDATES -gt 6 ]; then
+			echo $(($UPDATES-6));
+                else
 			echo "0";
 		fi
 	elif [ $OS == "debian" ]; then


### PR DESCRIPTION
Hello,

I've added fedora support to the distro script and os-updates scripts.

For distro:

- As Fedora contains /etc/redhat-release, I added a check for /etc/fedora-release before /etc/redhat-release. Output looks as follows:

21:48 $ ./distro
Fedora 25

For os-updates:

- Added DNF support/fedora support

Thanks!