### PR TITLE
Fixed correct amount of pipeline symbols when degrees symbol is missing.

### DIFF
--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -19,7 +19,7 @@ hddtemp=`which hddtemp 2>/dev/null`
 
 if [ "${hddtemp}" != "" ]; then
 	if [ -x "${hddtemp}" ]; then
-		content=`${hddtemp} -w -q ${disks} 2>/dev/null | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/°/\|/g';`
+		content=`${hddtemp} -w -q ${disks} 2>/dev/null | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g'`
 		if [ "${content}" != "" ]; then
 			echo '<<<hddtemp>>>'
 			echo ${content}


### PR DESCRIPTION
When the script is called through xinetd/check_mk (on my system), there is no degree symbol, but a space.
Changed the script to handle both correctly