### PR TITLE
Update shebang

### DIFF
--- a/snmp/phpfpm-sp
+++ b/snmp/phpfpm-sp
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 
 # add this to snmpd.conf as below... actual path to the script can vary
 # extend phpfpmsp /root/snmp-extends/phpfpm-sp


### PR DESCRIPTION
With the original shebang this script didn't work on Debian and Ubuntu machines. Using `/usr/bin/env bash` makes the script more portable.