### PR TITLE
make ntp-client.sh dd-wrt(with ipkg) friendly and remove bash requirement

### DIFF
--- a/snmp/ntp-client.sh
+++ b/snmp/ntp-client.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 ################################################################
 # copy this script to somewhere like /opt and make chmod +x it #
 # edit your snmpd.conf and include                             #
@@ -6,20 +6,13 @@
 # restart snmpd and activate the app for desired host          #
 # please make sure you have the path/binaries below            #
 ################################################################
-# Binaries and paths required                                  #
+# Binaries and paths required, please correct before using.    #
 ################################################################
-BIN_NTPQ="$(command -v ntpq)"
-BIN_GREP="$(command -v grep)"
-BIN_TR="$(command -v tr)"
-BIN_CUT="$(command -v cut)"
+BIN_NTPQ="/usr/bin/env ntpq"
+BIN_GREP="/usr/bin/env grep"
+BIN_TR="/usr/bin/env tr"
+BIN_SED="/usr/bin/env sed"
 ################################################################
 # Don't change anything unless you know what are you doing     #
 ################################################################
-CMD1=`$BIN_NTPQ -c rv | $BIN_GREP 'jitter' | $BIN_TR '\n' ' '`
-IFS=', ' read -r -a array <<< "$CMD1"
-
-for value in 2 3 4 5 6
-do
-	echo ${array["$value"]} | $BIN_CUT -d "=" -f 2
-done
-
+$BIN_NTPQ -c rv | $BIN_GREP jitter | $BIN_SED 's/[[:alpha:]=,_]/ /g' | $BIN_SED 's/^\ *[0-9]\ *//;' | $BIN_SED 's/\ \ */ /g' | $BIN_SED 's/\ $//' | $BIN_TR ' ' '\n'


### PR DESCRIPTION
Yes, I've signed the author stuff etc... For some reason this form is not present here...

Wooho!

For DD-WRT, install ntp via ipkg as ntpq does not come in the base.

root@wap0:/jffs/snmpd# ./ntp-client
50.060777
-8.028
29.335078
8.745
0.012
root@wap0:/jffs/snmpd# 