### PR TITLE
hddtemp: fix shell expansion for drive detection

### DIFF
--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -11,6 +11,9 @@
 # the source code distribution for details.
 #
 # requires which, find, awk and sed
+#
+# optionally, install gnu parallel for a significant performance boost 
+# on machines with large numbers of drives.
 
 # Try to use lsblk if available. Otherwise, use find.
 if type lsblk >/dev/null 2>&1; then
@@ -23,7 +26,13 @@ hddtemp=`which hddtemp 2>/dev/null`
 
 if [ "${hddtemp}" != "" ]; then
 	if [ -x "${hddtemp}" ]; then
-		content=`${hddtemp} -w -q ${disks} 2>/dev/null | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g'`
+		if type parallel > /dev/null 2>&1; then
+			# When available, use GNU parallel for a significant performance boost. hddtemp runs serially(!)
+			output=`parallel ${hddtemp} -w -q ::: ${disks} 2>/dev/null`
+		else
+			output=`${hddtemp} -w -q ${disks} 2>/dev/null`
+		fi
+		content=`echo "$output" | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g'`
 		if [ "${content}" != "" ]; then
 			echo '<<<hddtemp>>>'
 			echo ${content}

--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -13,7 +13,7 @@
 # requires which, awk and sed
 
 # If disks are missing, they can be added here:
-disks="/dev/hd? /dev/sd?"
+disks="/dev/hd* /dev/sd*"
 
 hddtemp=`which hddtemp 2>/dev/null`
 

--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -11,9 +11,6 @@
 # the source code distribution for details.
 #
 # requires which, find, awk and sed
-#
-# optionally, install gnu parallel for a significant performance boost 
-# on machines with large numbers of drives.
 
 # Try to use lsblk if available. Otherwise, use find.
 if type lsblk >/dev/null 2>&1; then
@@ -26,13 +23,7 @@ hddtemp=`which hddtemp 2>/dev/null`
 
 if [ "${hddtemp}" != "" ]; then
 	if [ -x "${hddtemp}" ]; then
-		if type parallel > /dev/null 2>&1; then
-			# When available, use GNU parallel for a significant performance boost. hddtemp runs serially(!)
-			output=`parallel ${hddtemp} -w -q ::: ${disks} 2>/dev/null`
-		else
-			output=`${hddtemp} -w -q ${disks} 2>/dev/null`
-		fi
-		content=`echo "$output" | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g'`
+		content=`${hddtemp} -w -q ${disks} 2>/dev/null | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g'`
 		if [ "${content}" != "" ]; then
 			echo '<<<hddtemp>>>'
 			echo ${content}

--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -10,10 +10,14 @@
 # option) any later version.  Please see LICENSE.txt at the top level of
 # the source code distribution for details.
 #
-# requires which, awk and sed
+# requires which, find, awk and sed
 
-# If disks are missing, they can be added here:
-disks="/dev/hd* /dev/sd*"
+# Try to use lsblk if available. Otherwise, use find.
+if type lsblk >/dev/null 2>&1; then
+  disks=`lsblk -dnp|cut -d' ' -f1 | tr '\n' ' '`
+else
+  disks=`find /dev -name '[sh]d[a-z]' -or -name '[sh]d[a-z][a-z]' | tr '\n' ' '`
+fi
 
 hddtemp=`which hddtemp 2>/dev/null`
 


### PR DESCRIPTION
I have a machine with 58 disks. hddtemp only detected 26 of them.

Currently the hddtemp script is only able to find 26 drives due to the use of '?'. Switching it to the more aggressive '*' will pick up drives after sda-sdz, like sdaa, sdab, etc.

I tried to think of some cases where you wouldn't want the full expansion but was unable to think of any.