### PR TITLE
hddtemp: parallelize calls to hddtemp for performance

### DIFF
--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -11,6 +11,9 @@
 # the source code distribution for details.
 #
 # requires which, find, awk and sed
+#
+# optionally, install gnu parallel for a significant performance boost 
+# on machines with large numbers of drives.
 
 # Try to use lsblk if available. Otherwise, use find.
 if type lsblk >/dev/null 2>&1; then
@@ -23,7 +26,13 @@ hddtemp=`which hddtemp 2>/dev/null`
 
 if [ "${hddtemp}" != "" ]; then
 	if [ -x "${hddtemp}" ]; then
-		content=`${hddtemp} -w -q ${disks} 2>/dev/null | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g'`
+		if type parallel > /dev/null 2>&1; then
+			# When available, use GNU parallel for a significant performance boost. hddtemp runs serially(!)
+			output=`parallel ${hddtemp} -w -q ::: ${disks} 2>/dev/null`
+		else
+			output=`${hddtemp} -w -q ${disks} 2>/dev/null`
+		fi
+		content=`echo "$output" | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g'`
 		if [ "${content}" != "" ]; then
 			echo '<<<hddtemp>>>'
 			echo ${content}


### PR DESCRIPTION
This poll script runs hddtemp with a list of all drives as arguments and reads the output. hddtemp scans each drive's SMART status serially, which scales poorly with a large number of drives.

In lieu of a patch to the actual hddtemp project, optionally use GNU parallel when available to parallelize the call to hddtemp.

In testing a machine with 58 drives I went from a runtime of about 5 seconds per run to 0.5s, a performance improvement of 10x.