### PR TITLE
Fix for first line as localhost

### DIFF
--- a/snmp/apache-stats.py
+++ b/snmp/apache-stats.py
@@ -48,7 +48,9 @@ scoreboardkey = [ '_', 'S', 'R', 'W', 'K', 'D', 'C', 'L', 'G', 'I', '.' ]
 params = {}
 for line in data.splitlines():
 	fields = line.split( ': ' )
-	if fields[0] == 'Scoreboard':
+	if len(fields) <= 1:
+                continue  # "localhost" as first line cause out of index error
+	elif fields[0] == 'Scoreboard':
 		# count up the scoreboard into states
 		states = {}
 		for state in scoreboardkey:


### PR DESCRIPTION
An example output like below where the first line of output is just "localhost" so it causes the splitting to cause an out of index error.

Example:
cat /tmp/apache-snmp
localhost
ServerVersion: Apache/2.4.25 (Ubuntu) PHP/5.6.30-5+deb.sury.org~trusty+2
ServerMPM: prefork
Server Built: 2016-12-21T00:00:00
CurrentTime: Thursday, 18-May-2017 19:26:43 EDT
RestartTime: Thursday, 18-May-2017 11:35:48 EDT
ParentServerConfigGeneration: 2
ParentServerMPMGeneration: 1
ServerUptimeSeconds: 28255
ServerUptime: 7 hours 50 minutes 55 seconds
Load1: 0.04
Load5: 0.05
Load15: 0.10
Total Accesses: 5367
Total kBytes: 61432
CPUUser: 19.69
CPUSystem: 1.05
CPUChildrenUser: 0
CPUChildrenSystem: 0
CPULoad: .0734029
Uptime: 28255
ReqPerSec: .189949
BytesPerSec: 2226.38
BytesPerReq: 11721
BusyWorkers: 1
IdleWorkers: 6
Scoreboard: ___....._.__.W........................................................................................................................................