### PR TITLE
hddtemp, ignore devices not supporting SMART

### DIFF
--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -32,7 +32,7 @@ if [ "${hddtemp}" != "" ]; then
 		else
 			output=`${hddtemp} -w -q ${disks} 2>/dev/null`
 		fi
-		content=`echo "$output" | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g' | tr -cd '\12\14\40-\176'`
+		content=`echo "$output" | awk '{ if ($0 !~ /not available/) { print $0 } }' | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g' | tr -cd '\12\14\40-\176'`
 		if [ "${content}" != "" ]; then
 			echo '<<<hddtemp>>>'
 			echo ${content}


### PR DESCRIPTION
To drop non-supported devices from hddtemp.