### PR TITLE
Replace Disk Id with Disk Serial in S.M.A.R.T script

### DIFF
--- a/snmp/smart
+++ b/snmp/smart
@@ -239,6 +239,7 @@ my $toReturn='';
 my $int=0;
 while ( defined($disks[$int]) ) {
 	my $disk=$disks[$int];
+	my $disk_sn=$disk;
 	my $output=`$smartctl -A /dev/$disk`;
 
 	my %IDs=( '5'=>'null',
@@ -329,8 +330,13 @@ while ( defined($disks[$int]) ) {
 	my $conveyance=scalar grep(/Conveyance/, @outputA);
 	my $selective=scalar grep(/Selective/, @outputA);
 	
+	# get the drive serial number
+	while (`$smartctl -i /dev/$disk` =~ /Serial Number:(.*)/g) {
+		$disk_sn = $1;
+		$disk_sn =~ s/^\s+|\s+$//g;
+	}
 
-	$toReturn=$toReturn.$disk.','.$IDs{'5'}.','.$IDs{'10'}.','.$IDs{'173'}.','.$IDs{'177'}.','.$IDs{'183'}.','.$IDs{'184'}.','.$IDs{'187'}.','.$IDs{'188'}
+	$toReturn=$toReturn.$disk_sn.','.$IDs{'5'}.','.$IDs{'10'}.','.$IDs{'173'}.','.$IDs{'177'}.','.$IDs{'183'}.','.$IDs{'184'}.','.$IDs{'187'}.','.$IDs{'188'}
 	    .','.$IDs{'190'} .','.$IDs{'194'}.','.$IDs{'196'}.','.$IDs{'197'}.','.$IDs{'198'}.','.$IDs{'199'}.','.$IDs{'231'}.','.$IDs{'233'}.','.
 		$completed.','.$interrupted.','.$read_failure.','.$unknown_failure.','.$extended.','.$short.','.$conveyance.','.$selective."\n";
 


### PR DESCRIPTION
The script currently uses the drive id as assigned by the OS. Those are not unique and can get shuffled around even without changing hardware; However, a bigger issue is encountered, when the user replaces a drive and the SMART data from the old drive gets mixed up with the new one, because the id was re-used.

The changes in this PR, replace the disk identifier with the disk's serial number (taken from `smartctl`). The user still specifies the disk identifiers on their system (e.g. `ada`, `sda`, etc.), but they are not used as identifiers in the output/graphs. This should allow for a much more precise monitoring and it should be consistent even if the hardware changes (for example, changing controller/raid cards or moving to a new chipset).

The script will fallback to disk identifier, if `smartctl` is unable to get a serial number from the disk.