### PR TITLE
SNMPd shell extends update

### DIFF
--- a/snmp/dhcp-status.sh
+++ b/snmp/dhcp-status.sh
@@ -1,16 +1,21 @@
-#!/bin/bash
-################################################################
-# copy this script to somewhere like /opt and make chmod +x it #
-# edit your snmpd.conf add the below line and restart snmpd    #
-# extend dhcpstats /opt/dhcp-status.sh                         #
-################################################################ 
+#!/usr/bin/env bash
+
+# - Copy this script to somewhere (like /opt/dhcp-status.sh)
+# - Make it executable (chmod +x /opt/dhcp-status.sh)
+# - Add the following line to your snmpd.conf file
+#   extend dhcpstats /opt/dhcp-status.sh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/dhcp-status.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - cat, grep, sed, sort, tr, wc
+PATH=$PATH
+
+# Leases location
 FILE_DHCP='/var/lib/dhcp/db/dhcpd.leases'
-BIN_CAT='/usr/bin/cat'
-BIN_GREP='/usr/bin/grep'
-BIN_TR='/usr/bin/tr'
-BIN_SED='/usr/bin/sed'
-BIN_SORT='/usr/bin/sort'
-BIN_WC='/usr/bin/wc'
+
+# Patterns
 DHCP_LEASES='^lease'
 DHCP_ACTIVE='^lease|binding state active'
 DHCP_EXPIRED='^lease|binding state expired'
@@ -22,9 +27,9 @@ DHCP_BACKUP='^lease|binding state backup'
 DHCP_FREE='^lease|binding state free'
 NO_ERROR='[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} binding'
 
-$BIN_CAT $FILE_DHCP | $BIN_GREP $DHCP_LEASES | $BIN_SORT -u | $BIN_WC -l
+cat $FILE_DHCP | grep $DHCP_LEASES | sort -u | wc -l | tr -d "[:blank:]"
 
 for state in "$DHCP_ACTIVE" "$DHCP_EXPIRED" "$DHCP_RELEASED" "$DHCP_ABANDONED" "$DHCP_RESET" "$DHCP_BOOTP" "$DHCP_BACKUP" "$DHCP_FREE"
 do
-        $BIN_GREP -E "$state"  $FILE_DHCP | $BIN_TR '\n' '|' | $BIN_SED 's/ {| //g' | $BIN_TR '|' '\n' | $BIN_GREP -E "$NO_ERROR" | $BIN_SORT -u | $BIN_WC -l
+    grep -E "$state" "$FILE_DHCP" | tr '\n' '|' | sed 's/ {| //g' | tr '|' '\n' | grep -E "$NO_ERROR" | sort -u | wc -l | tr -d "[:blank:]"
 done

--- a/snmp/exim-stats.sh
+++ b/snmp/exim-stats.sh
@@ -10,26 +10,19 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#################################################################
-# copy this script to /etc/snmp/ and make it executable:        #
-# chmod +x /etc/snmp/exim-stats.sh                              #
-# ------------------------------------------------------------- #
-# edit your snmpd.conf and include:                             #
-# extend exim-stats /etc/snmp/exim-stats.sh                     #
-# ------------------------------------------------------------- #
-# restart snmpd and activate the app for desired host           #
-#################################################################
-BIN_EXIM=`which exim`
-BIN_GREP=`which grep`
-BIN_WC=`which wc`
-CFG_EXIM_1='-bp'
-CFG_EXIM_2='-bpc'
-CFG_GREP='frozen'
-CFG_WC='-l'
-#################################################################
 
-FROZEN=`$BIN_EXIM $CFG_EXIM_1 | $BIN_GREP $CFG_GREP | $BIN_WC $CFG_WC`
-echo $FROZEN
+# - Copy this script to somewhere (like /opt/exim-stats.sh)
+# - Make it executable (chmod +x /opt/exim-stats.sh)
+# - Add the following line to your snmpd.conf file
+#   extend exim-stats /opt/exim-stats.sh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/exim-stats.sh"
 
-QUEUE=`$BIN_EXIM $CFG_EXIM_2`
-echo $QUEUE
+# You need the following tools to be in your PATH env, adjust accordingly
+# - exim, grep, wc
+PATH=$PATH
+
+echo exim -bp | grep 'frozen' | wc -l
+
+echo exim -bpc

--- a/snmp/nfs-stats.sh
+++ b/snmp/nfs-stats.sh
@@ -1,47 +1,49 @@
-#!/bin/bash
-############################################################
-# copy this file somewhere like /opt and chmod +x it       #
-# edit your snmpd.conf and add the below line and restart: #
-# extend nfs-stats /opt/nfs-stats.sh                       #
-############################################################
+#!/usr/bin/env bash
+
+# - Copy this script to somewhere (like /opt/nfs-stats.sh)
+# - Make it executable (chmod +x /opt/nfs-stats.sh)
+# - Add the following line to your snmpd.conf file
+#   extend nfs-stats /opt/nfs-stats.sh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/nfs-stats.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - awk, cat, mv, paste, rm, sed, tr
+PATH=$PATH
+
 CFG_NFSFILE='/proc/net/rpc/nfsd'
-BIN_CAT='/usr/bin/cat'
-BIN_SED='/usr/bin/sed'
-BIN_AWK='/usr/bin/awk'
-BIN_TR='/usr/bin/tr'
-BIN_PASTE='/usr/bin/paste'
-BIN_RM='/usr/bin/rm'
-BIN_MV='/usr/bin/mv'
+
 LOG_OLD='/tmp/nfsio_old'
 LOG_NEW='/tmp/nfsio_new'
 LOG_FIX='/tmp/nfsio_fix'
 
 #get reply cache (rc - values: hits, misses, nocache)
-$BIN_CAT $CFG_NFSFILE | $BIN_SED -n 1p | $BIN_AWK '{print $2,$3,$4}' | $BIN_TR " " "\n" > $LOG_NEW
+cat $CFG_NFSFILE | sed -n 1p | awk '{print $2,$3,$4}' | tr " " "\n" > $LOG_NEW
 
 #get server file handle (fh - values: lookup, anon, ncachedir, ncachenondir, stale)
-$BIN_CAT $CFG_NFSFILE | $BIN_SED -n 2p | $BIN_AWK '{print $2,$3,$4,$5,$6}' | $BIN_TR " " "\n" >> $LOG_NEW
+cat $CFG_NFSFILE | sed -n 2p | awk '{print $2,$3,$4,$5,$6}' | tr " " "\n" >> $LOG_NEW
 
 #get io bytes (io - values: read, write)
-$BIN_CAT $CFG_NFSFILE | $BIN_SED -n 3p | $BIN_AWK '{print $2,$3}' | $BIN_TR " " "\n" >> $LOG_NEW
+cat $CFG_NFSFILE | sed -n 3p | awk '{print $2,$3}' | tr " " "\n" >> $LOG_NEW
 
 #get read ahead cache (ra - values: cache_size, 0-10%, 10-20%, 20-30%, 30-40%, 40-50%, 50-60%, 60-70%, 70-80%, 80-90%, 90-100%, not-found)
-$BIN_CAT $CFG_NFSFILE | $BIN_SED -n 5p | $BIN_AWK '{print $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13}' | $BIN_TR " " "\n" >> $LOG_NEW
-$BIN_CAT $CFG_NFSFILE | $BIN_SED -n 5p | $BIN_AWK '{print $2}' > $LOG_FIX
+cat $CFG_NFSFILE | sed -n 5p | awk '{print $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13}' | tr " " "\n" >> $LOG_NEW
+cat $CFG_NFSFILE | sed -n 5p | awk '{print $2}' > $LOG_FIX
 
 #get server packet stats (net - values: all reads, udp packets, tcp packets, tcp conn)
-$BIN_CAT $CFG_NFSFILE | $BIN_SED -n 6p | $BIN_AWK '{print $2,$3,$4,$5}' | $BIN_TR " " "\n" >> $LOG_NEW
+cat $CFG_NFSFILE | sed -n 6p | awk '{print $2,$3,$4,$5}' | tr " " "\n" >> $LOG_NEW
 
 #get server rpc operations (rpc - values: calls, badcalls, badfmt, badauth, badclnt)
-$BIN_CAT $CFG_NFSFILE | $BIN_SED -n 7p | $BIN_AWK '{print $2,$3,$4,$5,$6}' | $BIN_TR " " "\n" >> $LOG_NEW
+cat $CFG_NFSFILE | sed -n 7p | awk '{print $2,$3,$4,$5,$6}' | tr " " "\n" >> $LOG_NEW
 
 #get nfs v3 stats (proc3 - values: null, getattr, setattr, lookup, access, readlink, read, write, create, mkdir, symlink, mknod, remove, rmdir, rename, link, readdir, readdirplus, fsstat, fsinfo, pathconf, commit)
-$BIN_CAT $CFG_NFSFILE | $BIN_SED -n 8p | $BIN_AWK '{print $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24}' | $BIN_TR " " "\n" >> $LOG_NEW
+cat $CFG_NFSFILE | sed -n 8p | awk '{print $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24}' | tr " " "\n" >> $LOG_NEW
 
-$BIN_PASTE $LOG_FIX
-$BIN_PASTE $LOG_NEW $LOG_OLD | while read a b ; do
+paste $LOG_FIX
+paste $LOG_NEW $LOG_OLD | while read a b ; do
   echo $(($a-$b))
 done
 
-$BIN_RM $LOG_OLD 2>&1
-$BIN_MV $LOG_NEW $LOG_OLD 2>&1
+rm $LOG_OLD 2>&1
+mv $LOG_NEW $LOG_OLD 2>&1

--- a/snmp/ntp-client.sh
+++ b/snmp/ntp-client.sh
@@ -1,25 +1,26 @@
 #!/usr/bin/env bash
-################################################################
-# copy this script to somewhere like /opt and make chmod +x it #
-# edit your snmpd.conf and include                             #
-# extend ntp-client /opt/ntp-client.sh                         #
-# restart snmpd and activate the app for desired host          #
-# please make sure you have the path/binaries below            #
-################################################################
-# Binaries and paths required                                  #
-################################################################
-BIN_NTPQ="$(command -v ntpq)"
-BIN_GREP="$(command -v grep)"
-BIN_TR="$(command -v tr)"
-BIN_CUT="$(command -v cut)"
-################################################################
-# Don't change anything unless you know what are you doing     #
-################################################################
-CMD1=`$BIN_NTPQ -c rv | $BIN_GREP 'jitter' | $BIN_TR '\n' ' '`
-IFS=', ' read -r -a array <<< "$CMD1"
 
-for value in 2 3 4 5 6
+# - Copy this script to somewhere (like /opt/ntp-client.sh)
+# - Make it executable (chmod +x /opt/ntp-client.sh)
+# - Add the following line to your snmpd.conf file
+#   extend ntp-client /opt/ntp-client.shh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/ntp-client.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - ntpq, sed
+PATH=$PATH
+
+NTP_STATUS=$(ntpq -c rv | sed 's/,/ /g')
+
+for i in $NTP_STATUS
 do
-	echo ${array["$value"]} | $BIN_CUT -d "=" -f 2
+	export $i 2> /dev/null
 done
 
+echo $offset
+echo $frequency
+echo $sys_jitter
+echo $clk_jitter
+echo $clk_wander

--- a/snmp/os-updates.sh
+++ b/snmp/os-updates.sh
@@ -1,68 +1,52 @@
 #!/usr/bin/env bash
-################################################################
-# copy this script to /etc/snmp/ and make it executable:       #
-# chmod +x /etc/snmp/os-updates.sh                             #
-# ------------------------------------------------------------ #
-# edit your snmpd.conf and include:                            #
-# extend osupdate /opt/os-updates.sh 			       #
-#--------------------------------------------------------------#
-# restart snmpd and activate the app for desired host          #
-#--------------------------------------------------------------#
-# please make sure you have the path/binaries below            #
-################################################################ 
-BIN_WC='/usr/bin/wc'
-BIN_GREP='/bin/grep'
-CMD_GREP='-c'
-CMD_WC='-l'
-BIN_ZYPPER='/usr/bin/zypper'
-CMD_ZYPPER='-q lu'
-BIN_YUM='/usr/bin/yum'
-CMD_YUM='-q check-update'
-BIN_DNF='/usr/bin/dnf'
-CMD_DNF='-q check-update'
-BIN_APT='/usr/bin/apt-get'
-CMD_APT='-qq -s upgrade'
-BIN_PACMAN='/usr/bin/pacman'
-CMD_PACMAN='-Sup'
 
-################################################################
-# Don't change anything unless you know what are you doing     #
-################################################################
-if [ -f $BIN_ZYPPER ]; then
+# - Copy this script to somewhere (like /opt/osupdate.sh)
+# - Make it executable (chmod +x /opt/osupdate.sh)
+# - Add the following line to your snmpd.conf file
+#   extend osupdate /opt/osupdate.sh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/osupdate.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - grep, wc
+PATH=$PATH
+
+if [ -x "$(command -v zypper)" ]; then
     # OpenSUSE
-    UPDATES=`$BIN_ZYPPER $CMD_ZYPPER | $BIN_WC $CMD_WC`
+    UPDATES=$(zypper -q lu | wc -l)
     if [ $UPDATES -gt 2 ]; then
         echo $(($UPDATES-2));
     else
         echo "0";
     fi
-elif [ -f $BIN_DNF ]; then
+elif [ -x "$(command -v dnf)" ]; then
     # Fedora
-    UPDATES=`$BIN_DNF $CMD_DNF | $BIN_WC $CMD_WC`
+    UPDATES=$(dnf -q check-update | wc -l)
     if [ $UPDATES -gt 1 ]; then
         echo $(($UPDATES-1));
     else
         echo "0";
     fi
-elif [ -f $BIN_PACMAN ]; then
+elif [ -x "$(command -v pacman)" ]; then
     # Arch
-    UPDATES=`$BIN_PACMAN $CMD_PACMAN | $BIN_WC $CMD_WC`
+    UPDATES=$(pacman -Sup | wc -l)
     if [ $UPDATES -gt 1 ]; then
         echo $(($UPDATES-1));
     else
         echo "0";
     fi
-elif [ -f $BIN_YUM ]; then
+elif [ -x "$(command -v yum)" ]; then
     # CentOS / Redhat
-    UPDATES=`$BIN_YUM $CMD_YUM | $BIN_WC $CMD_WC`
+    UPDATES=$(yum -q check-update | wc -l)
     if [ $UPDATES -gt 1 ]; then
         echo $(($UPDATES-1));
     else
         echo "0";
     fi
-elif [ -f $BIN_APT ]; then
+elif [ -x "$(command -v apt-get)" ]; then
     # Debian / Devuan / Ubuntu
-    UPDATES=`$BIN_APT $CMD_APT | $BIN_GREP $CMD_GREP 'Inst'`
+    UPDATES=$(apt-get -qq -s upgrade | grep -c 'Inst')
     if [ $UPDATES -gt 1 ]; then
         echo $UPDATES;
     else

--- a/snmp/powerdns-dnsdist
+++ b/snmp/powerdns-dnsdist
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+
+# - Copy this script to somewhere (like /opt/powerdns-dnsdist.sh)
+# - Make it executable (chmod +x /opt/powerdns-dnsdist.sh)
+# - Add the following line to your snmpd.conf file
+#   extend powerdns-dnsdist /opt/powerdns-dnsdist.sh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/powerdns-dnsdist.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - cat, curl, jq, grep
+PATH=$PATH
+
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -64,8 +77,8 @@ debug() {
 }
 
 exportdata() {
-        # get current data
-        curl -s -u$API_AUTH_USER:$API_AUTH_PASS $API_URL$API_STATS | jq '.' > $TMP_FILE
+    # get current data
+    curl -s -u$API_AUTH_USER:$API_AUTH_PASS $API_URL$API_STATS | jq '.' > $TMP_FILE
 
 	# generate export values
 	JSON_VALUES=$(cat $TMP_FILE)
@@ -115,7 +128,7 @@ exportdata() {
 	STAT_QUERIES_FAILURE=$(echo $JSON_VALUES | jq '."trunc-failures"')
 	echo $STAT_QUERIES_FAILURE
 
-        STAT_QUERIES_ACL_DROPS=$(echo $JSON_VALUES | jq '."acl-drops"')
+    STAT_QUERIES_ACL_DROPS=$(echo $JSON_VALUES | jq '."acl-drops"')
 	echo $STAT_QUERIES_ACL_DROPS
 
 	STAT_RULE_DROP=$(echo $JSON_VALUES | jq '."rule-drop"')
@@ -159,7 +172,8 @@ exportdata() {
 }
 
 if [ -z $* ]; then
-        exportdata
+    exportdata
 fi
+
 expr "$*" : ".*--help" > /dev/null && usage
 expr "$*" : ".*--debug" > /dev/null && debug

--- a/snmp/raspberry.sh
+++ b/snmp/raspberry.sh
@@ -1,10 +1,19 @@
-#!/bin/bash
-#######################################
-# please read DOCS to succesfully get #
-# raspberry sensors into your host    #
-#######################################
-picmd='/usr/bin/vcgencmd'
-pised='/bin/sed'
+#!/usr/bin/env bash
+
+# - Copy this script to somewhere (like /opt/raspberry.sh)
+# - Make it executable (chmod +x /opt/raspberry.sh)
+# - Add the following line to your snmpd.conf file
+#   extend raspberry /opt/raspberry.sh
+# - Add the following line to your sudoers file (you can use visudo)
+#   snmp ALL=(ALL) NOPASSWD: /opt/raspberry.sh, /usr/bin/vcgencmd*
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/raspberry.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - sed, sudo, vcgencmd
+PATH=$PATH
+
 getTemp='measure_temp'
 getVoltsCore='measure_volts core'
 getVoltsRamC='measure_volts sdram_c'
@@ -19,29 +28,29 @@ getStatusMPG4='codec_enabled MPG4'
 getStatusMJPG='codec_enabled MJPG'
 getStatusWMV9='codec_enabled WMV9'
 
-sudo $picmd $getTemp | $pised 's|[^0-9.]||g'
-sudo $picmd $getVoltsCore | $pised 's|[^0-9.]||g'
-sudo $picmd $getVoltsRamC | $pised 's|[^0-9.]||g'
-sudo $picmd $getVoltsRamI | $pised 's|[^0-9.]||g'
-sudo $picmd $getVoltsRamP | $pised 's|[^0-9.]||g'
-sudo $picmd $getFreqArm  | $pised 's/frequency(45)=//g'
-sudo $picmd $getFreqCore | $pised 's/frequency(1)=//g'
-sudo $picmd $getStatusH264 | $pised 's/H264=//g'
-sudo $picmd $getStatusMPG2 | $pised 's/MPG2=//g'
-sudo $picmd $getStatusWVC1 | $pised 's/WVC1=//g'
-sudo $picmd $getStatusMPG4 | $pised 's/MPG4=//g'
-sudo $picmd $getStatusMJPG | $pised 's/MJPG=//g'
-sudo $picmd $getStatusWMV9 | $pised 's/WMV9=//g'
-sudo $picmd $getStatusH264 | $pised 's/enabled/2/g'
-sudo $picmd $getStatusMPG2 | $pised 's/enabled/2/g'
-sudo $picmd $getStatusWVC1 | $pised 's/enabled/2/g'
-sudo $picmd $getStatusMPG4 | $pised 's/enabled/2/g'
-sudo $picmd $getStatusMJPG | $pised 's/enabled/2/g'
-sudo $picmd $getStatusWMV9 | $pised 's/enabled/2/g'
-sudo $picmd $getStatusWMV9 | $pised 's/enabled/2/g'
-sudo $picmd $getStatusH264 | $pised 's/disabled/1/g'
-sudo $picmd $getStatusMPG2 | $pised 's/disabled/1/g'
-sudo $picmd $getStatusWVC1 | $pised 's/disabled/1/g'
-sudo $picmd $getStatusMPG4 | $pised 's/disabled/1/g'
-sudo $picmd $getStatusMJPG | $pised 's/disabled/1/g'
-sudo $picmd $getStatusWMV9 | $pised 's/disabled/1/g'
+sudo vcgencmd $getTemp | sed 's|[^0-9.]||g'
+sudo vcgencmd $getVoltsCore | sed 's|[^0-9.]||g'
+sudo vcgencmd $getVoltsRamC | sed 's|[^0-9.]||g'
+sudo vcgencmd $getVoltsRamI | sed 's|[^0-9.]||g'
+sudo vcgencmd $getVoltsRamP | sed 's|[^0-9.]||g'
+sudo vcgencmd $getFreqArm  | sed 's/frequency(45)=//g'
+sudo vcgencmd $getFreqCore | sed 's/frequency(1)=//g'
+sudo vcgencmd $getStatusH264 | sed 's/H264=//g'
+sudo vcgencmd $getStatusMPG2 | sed 's/MPG2=//g'
+sudo vcgencmd $getStatusWVC1 | sed 's/WVC1=//g'
+sudo vcgencmd $getStatusMPG4 | sed 's/MPG4=//g'
+sudo vcgencmd $getStatusMJPG | sed 's/MJPG=//g'
+sudo vcgencmd $getStatusWMV9 | sed 's/WMV9=//g'
+sudo vcgencmd $getStatusH264 | sed 's/enabled/2/g'
+sudo vcgencmd $getStatusMPG2 | sed 's/enabled/2/g'
+sudo vcgencmd $getStatusWVC1 | sed 's/enabled/2/g'
+sudo vcgencmd $getStatusMPG4 | sed 's/enabled/2/g'
+sudo vcgencmd $getStatusMJPG | sed 's/enabled/2/g'
+sudo vcgencmd $getStatusWMV9 | sed 's/enabled/2/g'
+sudo vcgencmd $getStatusWMV9 | sed 's/enabled/2/g'
+sudo vcgencmd $getStatusH264 | sed 's/disabled/1/g'
+sudo vcgencmd $getStatusMPG2 | sed 's/disabled/1/g'
+sudo vcgencmd $getStatusWVC1 | sed 's/disabled/1/g'
+sudo vcgencmd $getStatusMPG4 | sed 's/disabled/1/g'
+sudo vcgencmd $getStatusMJPG | sed 's/disabled/1/g'
+sudo vcgencmd $getStatusWMV9 | sed 's/disabled/1/g'

--- a/snmp/sdfsinfo
+++ b/snmp/sdfsinfo
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 
-##################################################################
+# - Copy this script to somewhere (like /opt/sdfsinfo.sh)
+# - Make it executable (chmod +x /opt/sdfsinfo.sh)
+# - Add the following line to your snmpd.conf file
+#   extend sdfsinfo /opt/sdfsinfo.sh
+# - Restart snmpd
 #
+# Note: Change the path accordingly, if you're not using "/opt/sdfsinfo.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - sdfscli, grep
+PATH=$PATH
+
 # SDFS info SNMP extend script
 # datapoint -> info (type, descr):
 # 00 -> files (int)
@@ -15,12 +25,5 @@
 # 08 -> volume dedup rate (float, %)
 # 09 -> volume savings (float, %)
 # 10 -> compression rate (float, %)
-#
-##################################################################
 
-SDFSCLI_BIN=`which sdfscli`
-SDFSCLI_CMD=' --volume-info'
-GREP_BIN=`which grep`
-GREP_CMD=' -o -E '
-DATAPOINTS=`$SDFSCLI_BIN $SDFSCLI_CMD | $GREP_BIN $GREP_CMD "(([0-9]+)\.?([0-9]+)?)"`
-echo $DATAPOINTS
+sdfscli --volume-info | grep -o -E "(([0-9]+)\.?([0-9]+)?)"

--- a/snmp/squid
+++ b/snmp/squid
@@ -1,7 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# Add this to snmpd.conf as below.
-# extend squid /etc/snmp/squid
+# - Copy this script to somewhere (like /opt/squid.sh)
+# - Make it executable (chmod +x /opt/squid.sh)
+# - Add the following line to your snmpd.conf file
+#   extend squid /opt/squid.sh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/squid.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - snmpwalk
+PATH=$PATH
 
 # To get this working smoothly and securely, you can add the items below to your squid.conf.
 # acl snmppublic snmp_community public
@@ -9,15 +18,11 @@
 # snmp_access allow snmppublic localhost
 # snmp_access deny all
 
-
 # set this as being equal to the value of 'acl snmppublic snmp_community' in squid.conf
 community='public'
 
 # set this as being equal to the value of 'snmp_port' in squid.conf
 port='3401'
-
-# the full path to snmpwalk
-snmpwalk='/usr/bin/env snmpwalk'
 
 ##
 ## Nothing Should Need Changed Below Here
@@ -27,7 +32,7 @@ snmpwalk='/usr/bin/env snmpwalk'
 # cacheSwapMaxSize Integer32
 # cacheSwapHighWM Integer32
 # cacheSwapLowWM Integer32
-$snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.2.5
+snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.2.5
 
 # cacheSysPageFaults Counter32
 # cacheSysNumReads Counter32
@@ -43,7 +48,7 @@ $snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.2.5
 # cacheCurrentResFileDescrCnt Gauge32
 # cacheCurrentFileDescrCnt Gauge32
 # cacheCurrentFileDescrMax Gauge32
-$snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.1
+snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.1
 
 # cacheProtoClientHttpRequests Counter32
 # cacheHttpHits Counter32
@@ -60,15 +65,14 @@ $snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.1
 # cacheServerOutKb Counter32
 # cacheCurrentSwapSize Gauge32
 # cacheClients Gauge32 
-$snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.2.1
+snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.2.1
 
 # cacheRequestHitRatio.1 Integer32
 # cacheRequestHitRatio.5 Integer32
 # cacheRequestHitRatio.60 Integer32
-$snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.2.2.1.9
+snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.2.2.1.9
 
 # cacheRequestByteRatio.1 Integer32
 # cacheRequestByteRatio.5 Integer32
 # cacheRequestByteRatio.60 Integer32
-$snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.2.2.1.10
-
+snmpwalk -O qv -c $community -v 2c localhost:$port 1.3.6.1.4.1.3495.1.3.2.2.1.10

--- a/snmp/unbound
+++ b/snmp/unbound
@@ -1,13 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# Add this to snmpd.conf as below.
-# extend unbound /root/snmp-extends/unbound
+# - Copy this script to somewhere (like /opt/unbound.sh)
+# - Make it executable (chmod +x /opt/unbound.sh)
+# - Add the following line to your snmpd.conf file
+#   extend unbound /opt/unbound.sh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/unbound.sh"
 
-# Set the path to unbound-control.
-unbountctl='/usr/bin/env unbound-control'
+# You need the following tools to be in your PATH env, adjust accordingly
+# - unbound-control
+PATH=$PATH
 
-##
-## You should not need to change anything below.
-##
-
-$unbountctl stats
+unbound-control stats

--- a/snmp/ups-apcups.sh
+++ b/snmp/ups-apcups.sh
@@ -1,30 +1,28 @@
 #!/usr/bin/env bash
-################################################################
-# copy this script to /etc/snmp/ and make it executable:       #
-# chmod +x /etc/snmp/ups-apcups.sh                             #
-# ------------------------------------------------------------ #
-# edit your snmpd.conf and include:                            #
-# extend ups-apcups /etc/snmp/ups-apcups.sh                    #
-#--------------------------------------------------------------#
-# restart snmpd and activate the app for desired host          #
-#--------------------------------------------------------------#
-# please make sure you have the path/binaries below            #
-################################################################
-BIN_APCS='/sbin/apcaccess'
-BIN_TR='/usr/bin/tr'
-BIN_CUT='/usr/bin/cut'
-BIN_GREP='/usr/bin/grep'
-################################################################
-# Don't change anything unless you know what are you doing     #
-################################################################
-TMP=`$BIN_APCS 2>/dev/null`
 
-for value in "LINEV:[0-9]+" "LOADPCT:[0-9.]+" "BCHARGE:[0-9.]+" "TIMELEFT:[0-9.]+" "^BATTV:[0-9.]+" "NOMINV:[0-9]+" "NOMBATTV:[0-9.]+"
+# - Copy this script to somewhere (like /opt/ups-apcups.sh)
+# - Make it executable (chmod +x /opt/ups-apcups.sh)
+# - Change the UPS_NAME variable to match the name of your UPS
+# - Add the following line to your snmpd.conf file
+#   extend ups-apcups /opt/ups-apcups.sh
+# - Restart snmpd
+#
+# Note: Change the path accordingly, if you're not using "/opt/ups-apcups.sh"
+
+# You need the following tools to be in your PATH env, adjust accordingly
+# - apcaccess, cut, grep
+PATH=$PATH
+
+IFS=$'\n'
+for conf in $(apcaccess 2>/dev/null | grep ":" | awk -F":" '{gsub(/ /, "", $1);gsub(/^[ \t]+/, "", $2); print $1 "=" $2}')
 do
-        OUT=`echo "$TMP" | $BIN_TR -d ' ' | $BIN_GREP -Eo $value | $BIN_CUT -d ":" -f 2`
-        if [ -n "$OUT" ]; then
-                echo $OUT
-        else
-                echo "Unknown"
-        fi
+    export $conf
 done
+
+echo $BCHARGE   | cut -d " " -f1
+echo $TIMELEFT  | cut -d " " -f1
+echo $NOMBATTV  | cut -d " " -f1
+echo $BATTV     | cut -d " " -f1
+echo $LINEV     | cut -d " " -f1
+echo $NOMINV    | cut -d " " -f1
+echo $LOADPCT   | cut -d " " -f1


### PR DESCRIPTION
Changes:

- Remove variables as commands.
This makes the scripts unreadable and needlessly complicated. Reminding the user to update `PATH` seems like a much simpler solution.

- Add a simple guide how to setup each script
While this is already in the documentation, i think its helpful to have it in the file as well. Especially when editing over `ssh`.

- Rewrite NTP (`client`|`server`)
The main issue was that the previous scripts were relying on specific order of the output which might (did) change. This version uses `export` to create variables from the `ntpq` output and thus ensure the correct value in the correct order

- Rewrite UPS (`apc`|`nut`)
As with NTP, this rewrite uses variables to create the expected output. The `nut` and `apcaccess` output is being processed to make the variable name compatible with export.

- Fix DHCP lease status
The beginning of the string contained and empty space (`\x20`), which prevented the correct parsing of the output.

Not all scripts are being updated, feedback is appreciated as im not sure if some of the scripts are being readable/accessible enough.