### PR TITLE
Update fail2ban extend script to new JSON format

### DIFF
--- a/snmp/fail2ban
+++ b/snmp/fail2ban
@@ -105,8 +105,9 @@ sub main::HELP_MESSAGE {
 #generats stats
 sub stats{
 	my %toReturn;
-	$toReturn{total}=0; # total number in jails
-	$toReturn{jails}={}; # each jail
+	$toReturn{data}={};
+	$toReturn{data}{total}=0; # total number in jails
+	$toReturn{data}{jails}={}; # each jail
 	$toReturn{error}=0; # error code, 0 if good
 	$toReturn{errorString}=''; # detailed description of any errors
 	$toReturn{version}='1'; # format version of the returned data
@@ -147,8 +148,8 @@ sub stats{
 			$jailTotal=~s/\s//g;
 			
 			#tally the total and add this jail to the list
-			$toReturn{total} = $toReturn{total} + $jailTotal;
-			$toReturn{jails}{ $jails[$int] } = $jailTotal;
+			$toReturn{data}{total} = $toReturn{data}{total} + $jailTotal;
+			$toReturn{data}{jails}{ $jails[$int] } = $jailTotal;
 			
 			$int++;
 		}


### PR DESCRIPTION
As seen at [this location](https://github.com/librenms/librenms/blob/7fab99cfc13b80a543fb779d68c659b52fc074b1/includes/polling/functions.inc.php#L768) the JSON output needs to contain a `data` field. The poller php script actually also extracts this `data` field as one of the first steps, see at [this line](https://github.com/librenms/librenms/blob/c3007b483a12758042e5d0c6009a8ef48e3e1a39/includes/polling/applications/fail2ban.inc.php#L36).
Before I changed these parts the graph didn't show up because the RRD files simply weren't generated as an exception occurred in the poller. This fixes this problem.