### PR TITLE
Fix Debian detection on Proxmox - lsb_release binary doesn't exist

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -46,7 +46,7 @@ elif [ "${OS}" = "Linux" ] ; then
     DIST="Devuan `cat /etc/devuan_version`"
     REV=""
 
-  elif [ -f /etc/debian_version ] ; then
+  elif [ -f /etc/debian_version -a -f /usr/bin/lsb_release ] ; then
     DIST="Debian `cat /etc/debian_version`"
     REV=""
     ID=`lsb_release -i | awk -F ':' '{print $2}' | sed 's/	//g'`

--- a/snmp/distro
+++ b/snmp/distro
@@ -24,12 +24,16 @@ elif [ "${OS}" = "Linux" ] ; then
     DIST=$(cat /etc/redhat-release | awk '{print $1}')
     if [ "${DIST}" = "CentOS" ]; then
       DIST="CentOS"
+    elif [ "${DIST}" = "CloudLinux" ]; then
+      DIST="CloudLinux"
     elif [ "${DIST}" = "Mandriva" ]; then
       DIST="Mandriva"
       PSEUDONAME=`cat /etc/mandriva-release | sed s/.*\(// | sed s/\)//`
       REV=`cat /etc/mandriva-release | sed s/.*release\ // | sed s/\ .*//`
     elif [ -f /etc/oracle-release ]; then
       DIST="Oracle"
+    elif [ -f /etc/rockstor-release ]; then
+      DIST="Rockstor"
     else
       DIST="RedHat"
     fi
@@ -62,6 +66,11 @@ elif [ "${OS}" = "Linux" ] ; then
     DIST="Arch Linux"
     REV="" # Omit version since Arch Linux uses rolling releases
     IGNORE_LSB=1 # /etc/lsb-release would overwrite $REV with "rolling"
+    
+  elif [ -f /etc/photon-release ] ; then
+    DIST=$(head -1 < /etc/photon-release)
+    REV=$(sed -n -e 's/^.*PHOTON_BUILD_NUMBER=//p' /etc/photon-release)
+    IGNORE_LSB=1 # photon os does not have /etc/lsb-release nor lsb_release
 
   elif [ -f /etc/os-release ] ; then
     DIST=$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '"')
@@ -91,8 +100,14 @@ elif [ "${OS}" = "Linux" ] ; then
     fi
   fi
 
-  if [ "`uname -a | awk '{print $(NF)}'`" = "DD-WRT" ] ; then
-    DIST="dd-wrt"
+  if [ -x "$(command -v  awk)" ];  then # some distros do not ship with awk
+    if [ "`uname -a | awk '{print $(NF)}'`" = "DD-WRT" ] ; then
+      DIST="dd-wrt"
+    fi    
+    if [ "`uname -a | awk '{print $(NF)}'`" = "ASUSWRT-Merlin" ] ; then
+      DIST="ASUSWRT-Merlin"
+      REV=`nvram show | grep buildno= | egrep -o '[0-9].[0-9].[0-9]'` > /dev/null 2>&1
+    fi
   fi
 
   if [ -n "${REV}" ]


### PR DESCRIPTION
IF condition for Debian systems also checks if lsb-release package is installed on the system.

Proxmox doesn't have it installed by default, for example.