### PR TITLE
PhotonOS distro detection

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -101,12 +101,11 @@ elif [ "${OS}" = "Linux" ] ; then
   if [ -x "$(command -v  awk)" ];  then # some distros do not ship with awk
     if [ "`uname -a | awk '{print $(NF)}'`" = "DD-WRT" ] ; then
       DIST="dd-wrt"
+    fi    
+    if [ "`uname -a | awk '{print $(NF)}'`" = "ASUSWRT-Merlin" ] ; then
+      DIST="ASUSWRT-Merlin"
+      REV=`nvram show | grep buildno= | egrep -o '[0-9].[0-9].[0-9]'` > /dev/null 2>&1
     fi
-  fi
-
-  if [ "`uname -a | awk '{print $(NF)}'`" = "ASUSWRT-Merlin" ] ; then
-    DIST="ASUSWRT-Merlin"
-    REV=`nvram show | grep buildno= | egrep -o '[0-9].[0-9].[0-9]'` > /dev/null 2>&1
   fi
 
   if [ -n "${REV}" ]

--- a/snmp/distro
+++ b/snmp/distro
@@ -64,6 +64,11 @@ elif [ "${OS}" = "Linux" ] ; then
     DIST="Arch Linux"
     REV="" # Omit version since Arch Linux uses rolling releases
     IGNORE_LSB=1 # /etc/lsb-release would overwrite $REV with "rolling"
+    
+  elif [ -f /etc/photon-release ] ; then
+    DIST=$(head -1 < /etc/photon-release)
+    REV=$(sed -n -e 's/^.*PHOTON_BUILD_NUMBER=//p' /etc/photon-release)
+    IGNORE_LSB=1 # photon os does not have /etc/lsb-release nor lsb_release
 
   elif [ -f /etc/os-release ] ; then
     DIST=$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '"')
@@ -93,8 +98,10 @@ elif [ "${OS}" = "Linux" ] ; then
     fi
   fi
 
-  if [ "`uname -a | awk '{print $(NF)}'`" = "DD-WRT" ] ; then
-    DIST="dd-wrt"
+  if [ -x "$(command -v  awk)" ];  then # some distros do not ship with awk
+    if [ "`uname -a | awk '{print $(NF)}'`" = "DD-WRT" ] ; then
+      DIST="dd-wrt"
+    fi
   fi
 
   if [ -n "${REV}" ]


### PR DESCRIPTION
Detection before `/etc/os-release` since that is present yet missing the build number.

Not many people run PhotonOS so here are some screenshots:
Before:
![image](https://user-images.githubusercontent.com/14022915/45643477-2cd14c00-ba89-11e8-9068-3ec0307fef98.png)
After:
![image](https://user-images.githubusercontent.com/14022915/45643431-162af500-ba89-11e8-929d-8644faea3173.png)
