### PR TITLE
Correct indenting in nginx script

### DIFF
--- a/snmp/nginx
+++ b/snmp/nginx
@@ -10,13 +10,13 @@ for line in data.split("\n"):
     smallstat = re.match(r"\s?Reading:\s(.*)\sWriting:\s(.*)\sWaiting:\s(.*)$", line)
     req = re.match(r"\s+(\d+)\s+(\d+)\s+(\d+)", line)
     if smallstat:
-  params["Reading"] = smallstat.group(1)
-  params["Writing"] = smallstat.group(2)
-  params["Waiting"] = smallstat.group(3)
+        params["Reading"] = smallstat.group(1)
+        params["Writing"] = smallstat.group(2)
+        params["Waiting"] = smallstat.group(3)
     elif req:
-  params["Requests"] = req.group(3)
+        params["Requests"] = req.group(3)
     else:
-  pass
+        pass
 
 dataorder = [
   "Active",
@@ -28,7 +28,7 @@ dataorder = [
 
 for param in dataorder:
     if param == "Active":
-  Active = int(params["Reading"]) + int(params["Writing"]) + int(params["Waiting"])
-  print Active
+        Active = int(params["Reading"]) + int(params["Writing"]) + int(params["Waiting"])
+        print Active
     else:
-  print params[param]
+        print params[param]


### PR DESCRIPTION
There is an error in the current `snmp/nginx` script where the indenting is not correct. This should be 8 spaces instead of the current 2. This pull request fixes that.