### PR TITLE
Use which to solve executables path

### DIFF
--- a/snmp/asterisk
+++ b/snmp/asterisk
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ASCLI=/usr/sbin/asterisk
+ASCLI=`which asterisk`
 
 if [ -f $ASCLI ];
 then

--- a/snmp/dhcp-status.sh
+++ b/snmp/dhcp-status.sh
@@ -5,12 +5,12 @@
 # extend dhcpstats /opt/dhcp-status.sh                         #
 ################################################################ 
 FILE_DHCP='/var/lib/dhcp/db/dhcpd.leases'
-BIN_CAT='/usr/bin/cat'
-BIN_GREP='/usr/bin/grep'
-BIN_TR='/usr/bin/tr'
-BIN_SED='/usr/bin/sed'
-BIN_SORT='/usr/bin/sort'
-BIN_WC='/usr/bin/wc'
+BIN_CAT=`which cat`
+BIN_GREP=`which grep`
+BIN_TR=`which tr`
+BIN_SED=`which sed`
+BIN_SORT=`which sort`
+BIN_WC=`which wc`
 DHCP_LEASES='^lease'
 DHCP_ACTIVE='^lease|binding state active'
 DHCP_EXPIRED='^lease|binding state expired'

--- a/snmp/freeradius.sh
+++ b/snmp/freeradius.sh
@@ -12,8 +12,8 @@ RADIUS_KEY='adminsecret'
 RADIUS_STATUS_CMD='Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 31, Response-Packet-Type = Access-Accept'
 
 # Pathes for grep and radclient executables, should work if within PATH
-BIN_GREP="$(command -v grep)"
-BIN_RADCLIENT="$(command -v radclient)"
+BIN_GREP=`which grep`
+BIN_RADCLIENT=`which radclient`
 
 if [ $AGENT == 1 ]; then
   echo "<<<freeradius>>>"

--- a/snmp/nfs-stats.sh
+++ b/snmp/nfs-stats.sh
@@ -5,13 +5,13 @@
 # extend nfs-stats /opt/nfs-stats.sh                       #
 ############################################################
 CFG_NFSFILE='/proc/net/rpc/nfsd'
-BIN_CAT='/usr/bin/cat'
-BIN_SED='/usr/bin/sed'
-BIN_AWK='/usr/bin/awk'
-BIN_TR='/usr/bin/tr'
-BIN_PASTE='/usr/bin/paste'
-BIN_RM='/usr/bin/rm'
-BIN_MV='/usr/bin/mv'
+BIN_CAT=`which cat`
+BIN_SED=`which sed`
+BIN_AWK=`which awk`
+BIN_TR=`which tr`
+BIN_PASTE=`which paste`
+BIN_RM=`which rm`
+BIN_MV=`which mv`
 LOG_OLD='/tmp/nfsio_old'
 LOG_NEW='/tmp/nfsio_new'
 LOG_FIX='/tmp/nfsio_fix'

--- a/snmp/ntp-client
+++ b/snmp/ntp-client
@@ -12,11 +12,11 @@
 ################################################################
 # Don't change anything unless you know what are you doing     #
 ################################################################
-BIN_NTPQ='/usr/bin/env ntpq'
-BIN_NTPD='/usr/bin/env ntpd'
-BIN_GREP='/usr/bin/env grep'
-BIN_AWK='/usr/bin/env awk'
-BIN_HEAD='/usr/bin/env head'
+BIN_NTPQ=`which ntpq`
+BIN_NTPD=`which ntpd`
+BIN_GREP=`which grep`
+BIN_AWK=`which awk`
+BIN_HEAD=`which head`
 
 CONFIG=$0".conf"
 if [ -f $CONFIG ]; then

--- a/snmp/ntp-server.sh
+++ b/snmp/ntp-server.sh
@@ -10,14 +10,14 @@
 # If you are unsure, which to set, run this script and make sure that
 # the JSON output variables match that in "ntpq -c rv".
 #
-BIN_NTPD='/usr/bin/env ntpd'
-BIN_NTPQ='/usr/bin/env ntpq'
-BIN_NTPDC='/usr/bin/env ntpdc'
-BIN_GREP='/usr/bin/env grep'
-BIN_TR='/usr/bin/env tr'
-BIN_CUT='/usr/bin/env cut'
-BIN_SED="/usr/bin/env sed"
-BIN_AWK='/usr/bin/env awk'
+BIN_NTPD=`which ntpd`
+BIN_NTPQ=`which ntpq`
+BIN_NTPDC=`which ntpdc`
+BIN_GREP=`which grep`
+BIN_TR=`which tr`
+BIN_CUT=`which cut`
+BIN_SED=`which sed`
+BIN_AWK=`which awk`
 NTPQV="p11"
 ################################################################
 # Don't change anything unless you know what are you doing     #

--- a/snmp/nvidia
+++ b/snmp/nvidia
@@ -4,9 +4,9 @@
 # extend nvidia /etc/snmps/nvidia
 
 # Please verify the following paths are correct
-nvidiasmi='/usr/bin/env nvidia-smi'
-grep='/usr/bin/env grep'
-sed='/usr/bin/env sed'
+nvidiasmi=`which nvidia-smi`
+grep=`which grep`
+sed=`which sed`
 
 ##
 ## Nothing below here should need touched.

--- a/snmp/osupdate
+++ b/snmp/osupdate
@@ -10,19 +10,19 @@
 #--------------------------------------------------------------#
 # please make sure you have the path/binaries below            #
 ################################################################
-BIN_WC='/usr/bin/env wc'
-BIN_GREP='/usr/bin/env grep'
-CMD_GREP='-c'
+BIN_WC=`which wc`
 CMD_WC='-l'
-BIN_ZYPPER='/usr/bin/env zypper'
+BIN_GREP=`which grep`
+CMD_GREP='-c'
+BIN_ZYPPER=`which zypper`
 CMD_ZYPPER='-q lu'
-BIN_YUM='/usr/bin/env yum'
+BIN_YUM=`which yum`
 CMD_YUM='-q check-update'
-BIN_DNF='/usr/bin/env dnf'
+BIN_DNF=`which dnf`
 CMD_DNF='-q check-update'
-BIN_APT='/usr/bin/env apt-get'
+BIN_APT=`which apt-get`
 CMD_APT='-qq -s upgrade'
-BIN_PACMAN='/usr/bin/env pacman'
+BIN_PACMAN=`which pacman`
 CMD_PACMAN='-Sup'
 
 ################################################################

--- a/snmp/powerdns-dnsdist
+++ b/snmp/powerdns-dnsdist
@@ -9,7 +9,7 @@ API_STATS="jsonstat?command=stats"
 TMP_FILE="/tmp/dnsdist_current.stats"
 
 #/ Description: BASH script to get PowerDNS dnsdist stats
-#/ Examples: ./powerdns-dnsdist
+#/ Examples: ./powerdns-dnsdist.sh
 #/ Options:
 #/   --help: Display this help message
 #/   --debug: Brief check of system env and script vars

--- a/snmp/raspberry.sh
+++ b/snmp/raspberry.sh
@@ -3,8 +3,8 @@
 # please read DOCS to succesfully get #
 # raspberry sensors into your host    #
 #######################################
-picmd='/usr/bin/vcgencmd'
-pised='/bin/sed'
+picmd=`which vcgencmd`
+pised=`which sed`
 getTemp='measure_temp'
 getVoltsCore='measure_volts core'
 getVoltsRamC='measure_volts sdram_c'

--- a/snmp/squid
+++ b/snmp/squid
@@ -17,7 +17,7 @@ community='public'
 port='3401'
 
 # the full path to snmpwalk
-snmpwalk='/usr/bin/env snmpwalk'
+snmpwalk=`which snmpwalk`
 
 ##
 ## Nothing Should Need Changed Below Here

--- a/snmp/unbound
+++ b/snmp/unbound
@@ -4,7 +4,7 @@
 # extend unbound /root/snmp-extends/unbound
 
 # Set the path to unbound-control.
-unbountctl='/usr/bin/env unbound-control'
+unbountctl=`which unbound-control`
 
 ##
 ## You should not need to change anything below.

--- a/snmp/ups-apcups.sh
+++ b/snmp/ups-apcups.sh
@@ -10,10 +10,10 @@
 #--------------------------------------------------------------#
 # please make sure you have the path/binaries below            #
 ################################################################
-BIN_APCS='/sbin/apcaccess'
-BIN_TR='/usr/bin/tr'
-BIN_CUT='/usr/bin/cut'
-BIN_GREP='/usr/bin/grep'
+BIN_APCS=`which apcaccess`
+BIN_TR=`which tr`
+BIN_CUT=`which cut`
+BIN_GREP=`which grep`
 ################################################################
 # Don't change anything unless you know what are you doing     #
 ################################################################


### PR DESCRIPTION
I've got many errors while using some agent scripts :

```
/etc/snmp/dhcp-status.sh: line 25: /usr/bin/cat: No such file or directory
/etc/snmp/dhcp-status.sh: line 25: /usr/bin/grep: No such file or directory
0
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/grep: No such file or directory
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/sed: No such file or directory
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/grep: No such file or directory
0
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/grep: No such file or directory
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/sed: No such file or directory
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/grep: No such file or directory
0
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/grep: No such file or directory
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/sed: No such file or directory
/etc/snmp/dhcp-status.sh: line 29: /usr/bin/grep: No such file or directory
```

We should use which to solve executables path.