### PR TITLE
Added Ubuntu 14.04 zfs support

### DIFF
--- a/snmp/zfs-linux
+++ b/snmp/zfs-linux
@@ -2,6 +2,13 @@
 import json
 import subprocess
 
+def proc_err(cmd, proc):
+    # output process error and first line of error code
+    return "{}{}".format(
+        subprocess.CalledProcessError(proc.returncode, cmd, proc.stderr),
+        " ({})".format(proc.stderr.splitlines()[0]) if proc.stderr.splitlines() else ""
+    )
+
 def main(args):
     res = {}
 
@@ -95,9 +102,24 @@ def main(args):
     PREFETCH_METADATA_MISSES_PERCENT = DEMAND_METADATA_MISSES / ARC_MISSES * 100
 
     # pools
-    proc = subprocess.run(['/sbin/zpool', 'list', '-pH'], stdout=subprocess.PIPE, universal_newlines=True)
-    if proc.returncode != 0:
-        return proc.returncode
+    exact_size = True
+    zpool_cmd = ['/sbin/zpool']
+    zpool_cmd_list = zpool_cmd + ['list', '-p', '-H']
+    std = {'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE, 'universal_newlines': True}
+
+    ## account for variations between ZoL zfs versions
+    proc = subprocess.run(zpool_cmd_list, **std)
+    if (proc.returncode == 1) and (('root' in proc.stderr) or ('admin' in proc.stderr)):
+        zpool_cmd = ['sudo'] + zpool_cmd  # elevate zpool with sudo
+        zpool_cmd_list = zpool_cmd + ['list', '-p', '-H']
+        proc = subprocess.run(zpool_cmd_list, **std)
+    if (proc.returncode == 2):
+        # -p option is not present in older versions
+        del zpool_cmd_list[zpool_cmd_list.index('-p')]  # try removing -p to fix the issue
+        proc = subprocess.run(zpool_cmd_list, **std)
+        exact_size = False
+    if (proc.returncode != 0):
+        return proc_err(zpool_cmd_list, proc)
 
     pools = []
     FIELDS = ['name', 'size', 'alloc', 'free', 'expandsz', 'frag', 'cap', 'dedup']
@@ -109,6 +131,18 @@ def main(args):
         info['frag'] = 0 if info['frag'] == '-' else info['frag']
         info['dedup'] = info['dedup'].rstrip('x')
         info['cap'] = info['cap'].rstrip('%')
+
+        # zfs-06.5.11 fix
+        if not exact_size:
+            zpool_cmd_get = zpool_cmd + ['get', '-pH', 'size,alloc,free', info['name']]
+            proc2 = subprocess.run(zpool_cmd_get, **std)
+            if (proc2.returncode != 0):
+                return proc_err(zpool_cmd_get, proc2)
+
+            info2 = dict([tuple(s.split('\t')[1:3]) for s in proc2.stdout.splitlines()])
+            info['size'] = info2['size']
+            info['alloc'] = info2['allocated']
+            info['free'] = info2['free']
 
         pools.append(info)
 

--- a/snmp/zfs-linux
+++ b/snmp/zfs-linux
@@ -109,12 +109,12 @@ def main(args):
 
     ## account for variations between ZoL zfs versions
     proc = subprocess.run(zpool_cmd_list, **std)
-    if (proc.returncode == 1) and (('root' in proc.stderr) or ('admin' in proc.stderr)):
-        zpool_cmd = ['sudo'] + zpool_cmd  # elevate zpool with sudo
-        zpool_cmd_list = zpool_cmd + ['list', '-p', '-H']
-        proc = subprocess.run(zpool_cmd_list, **std)
     if (proc.returncode == 2):
         # -p option is not present in older versions
+        # edit snmpd.conf zfs extend section to the following:
+        #   extend zfs /usr/bin/sudo /etc/snmp/zfs-linux
+        # make sure to edit your sudo users (usually visudo) and add at the bottom:
+        #   snmp ALL=(ALL) NOPASSWD: /etc/snmp/zfs-linux
         del zpool_cmd_list[zpool_cmd_list.index('-p')]  # try removing -p to fix the issue
         proc = subprocess.run(zpool_cmd_list, **std)
         exact_size = False


### PR DESCRIPTION
## Overview
For Ubuntu 14.04, [ZoL](https://zfsonlinux.org/) page gives the [zfs-native](https://launchpad.net/~zfs-native/+archive/ubuntu/stable) PPA.  It's currently using [zfs-06.5.11](https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.6.5.11) revision.  This poses a few issues with the current [zfs-linux](https://github.com/librenms/librenms-agent/blob/d49fe954dfdeffbeee091051f1f0c515d020f281/snmp/zfs-linux) script:
1. Run Permissions:
    - [zfs-0.7.0](https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.7.0) changed permissions so non-privileged users can run `zpool list`
2. Parsable list flag:
    - [zfs-0.7.0-rc1](https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.7.0-rc1) added the `-p` in https://github.com/zfsonlinux/zfs/commit/2a8b84b747cb27a175aa3a45b8cdb293cde31886
3. Ubuntu 14.04 supports [Python 3.4.0](https://packages.ubuntu.com/trusty/python3) as `python3`:
    - `subprocess.run()` command works with Python 3.5 and above.

### Fix 1
Add `snmp` to the **sudoers** file via `visudo`,
```bash
snmp  ALL=(root) NOPASSWD: /etc/snmp/zfs-linux
```
and added `sudo` to the extend command.
```bash
extend zfs /usr/bin/sudo /etc/snmp/zfs-linux
```
Even though `snmp` is ran as root, it still needs the extra permissions in the sudoers file.

### Fix 2
Catch `-p` error within the [list](https://github.com/Kovrinic/librenms-agent/blob/166d1022f3671815af7d2d2cd6ae42b6d5d7f2d0/snmp/zfs-linux#L112:L120) command, and instead get the parsable values from the [get](https://github.com/Kovrinic/librenms-agent/blob/166d1022f3671815af7d2d2cd6ae42b6d5d7f2d0/snmp/zfs-linux#L135:L145) command.

### Fix 3
The user will need to manually install `python3.5` _(or higher)_ as the system wide `python3` interpreter.  If they wish to preserve the system `python3` interpreter, then can install from source with `make altinstall` and then add full python3.# path to this script's [shebang](https://github.com/Kovrinic/librenms-agent/blob/166d1022f3671815af7d2d2cd6ae42b6d5d7f2d0/snmp/zfs-linux#L1).

Example: my system has `python3.7` installed via `make altinstall`.
```bash
$ which python3.7
/usr/local/bin/python3.7
```
Change [shebang](https://github.com/Kovrinic/librenms-agent/blob/166d1022f3671815af7d2d2cd6ae42b6d5d7f2d0/snmp/zfs-linux#L1) path to
```py
#!/usr/local/bin/python3.7
```

This is excessive detail for installing and using alternative version of Python, but wanted to outline the basics for posterity.