### PR TITLE
Fix Debian detection on Proxmox - lsb_release binary doesn't exist

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -54,10 +54,10 @@ elif [ "${OS}" = "Linux" ] ; then
     DIST="Debian `cat /etc/debian_version`"
     REV=""
     if [ -f /usr/bin/lsb_release ] ; then
-        ID=`lsb_release -i | awk -F ':' '{print $2}' | sed 's/	//g'`
+      ID=`lsb_release -i | awk -F ':' '{print $2}' | sed 's/	//g'`
     fi
     if [ "${ID}" = "Raspbian" ] ; then
-        DIST="Raspbian `cat /etc/debian_version`"
+      DIST="Raspbian `cat /etc/debian_version`"
     fi
 
   elif [ -f /etc/gentoo-release ] ; then

--- a/snmp/distro
+++ b/snmp/distro
@@ -50,12 +50,14 @@ elif [ "${OS}" = "Linux" ] ; then
     DIST="Devuan `cat /etc/devuan_version`"
     REV=""
 
-  elif [ -f /etc/debian_version -a -f /usr/bin/lsb_release ] ; then
+  elif [ -f /etc/debian_version ] ; then
     DIST="Debian `cat /etc/debian_version`"
     REV=""
-    ID=`lsb_release -i | awk -F ':' '{print $2}' | sed 's/	//g'`
+    if [ -f /usr/bin/lsb_release ] ; then
+        ID=`lsb_release -i | awk -F ':' '{print $2}' | sed 's/	//g'`
+    fi
     if [ "${ID}" = "Raspbian" ] ; then
-      DIST="Raspbian `cat /etc/debian_version`"
+        DIST="Raspbian `cat /etc/debian_version`"
     fi
 
   elif [ -f /etc/gentoo-release ] ; then

--- a/snmp/distro
+++ b/snmp/distro
@@ -50,7 +50,7 @@ elif [ "${OS}" = "Linux" ] ; then
     DIST="Devuan `cat /etc/devuan_version`"
     REV=""
 
-  elif [ -f /etc/debian_version ] ; then
+  elif [ -f /etc/debian_version -a -f /usr/bin/lsb_release ] ; then
     DIST="Debian `cat /etc/debian_version`"
     REV=""
     ID=`lsb_release -i | awk -F ':' '{print $2}' | sed 's/	//g'`


### PR DESCRIPTION
IF condition for Debian systems also checks if lsb-release package is installed on the system.

Proxmox doesn't have it installed by default, for example.

This could also work with

```
elif [ -f /etc/debian_version ] ; then
    DIST="Debian `cat /etc/debian_version`"
    REV=""
    if [ -f /usr/bin/lsb_release ] ; then
        ID=`lsb_release -i | awk -F ':' '{print $2}' | sed 's/	//g'`
    fi
    if [ "${ID}" = "Raspbian" ] ; then
        DIST="Raspbian `cat /etc/debian_version`"
    fi
```

Let me know which one would you prefer :)