### PR TITLE
Added Proxmox VE Versoin support

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -59,7 +59,10 @@ elif [ "${OS}" = "Linux" ] ; then
     if [ "${ID}" = "Raspbian" ] ; then
       DIST="Raspbian `cat /etc/debian_version`"
     fi
-
+    if [ -f /usr/bin/pveversion ]; then
+      DIST="${DIST}/PVE `/usr/bin/pveversion | cut -d '/' -f 2`"
+    fi
+    
   elif [ -f /etc/gentoo-release ] ; then
     DIST="Gentoo"
     REV=$(tr -d '[[:alpha:]]' </etc/gentoo-release | tr -d " ")


### PR DESCRIPTION
Hi, 

I added Proxmox VE (PVE) information support, as shown in the figure.

For example:  (Debian 9.6/PVE 5.3-5)


![2018-12-25 09_16_41-devices - librenms](https://user-images.githubusercontent.com/30381035/50408506-212eb780-0826-11e9-9a88-fe110ec99ac5.png)

