### PR TITLE
Fix: zpool list output changed, incorrect values

### DIFF
--- a/snmp/zfs-freebsd
+++ b/snmp/zfs-freebsd
@@ -51,7 +51,7 @@ use Getopt::Std;
 
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
 sub main::VERSION_MESSAGE {
-        print "FreeBSD ZFS stats extend 0.1.0\n";
+        print "FreeBSD ZFS stats extend 0.2.0\n";
 }
 
 sub main::HELP_MESSAGE {

--- a/snmp/zfs-freebsd
+++ b/snmp/zfs-freebsd
@@ -236,14 +236,14 @@ my $pools_int=0;
 my @toShoveIntoJSON;
 while ( defined( $pools[$pools_int] ) ) {
 	my %newPool;
-	
+
 	my $pool=$pools[$pools_int];
 	$pool =~ s/\t/,/g;
-	$pool =~ s/\,\-\,/\,0\,/g;
+	$pool =~ s/\,\-\,\-\,/\,0\,0\,/g;
 	$pool =~ s/\%//g;
 	$pool =~ s/\,([0-1\.]*)x\,/,$1,/;
 
-	( $newPool{name}, $newPool{size}, $newPool{alloc}, $newPool{free}, $newPool{ckpoint}, $newPool{expandsz}, $newPool{frag}, $newPool{cap}, $newPool{dedup}, $newPool{health} )=split(/\,/, $pool);
+	( $newPool{name}, $newPool{size}, $newPool{alloc}, $newPool{free}, $newPool{ckpoint}, $newPool{expandsz}, $newPool{frag}, $newPool{cap}, $newPool{dedup} )=split(/\,/, $pool);
 
 	push(@toShoveIntoJSON, \%newPool);
 

--- a/snmp/zfs-freebsd
+++ b/snmp/zfs-freebsd
@@ -253,7 +253,7 @@ $tojson{pools}=\@toShoveIntoJSON;
 
 my %head_hash;
 $head_hash{'data'}=\%tojson;
-$head_hash{'version'}=1;
+$head_hash{'version'}=2;
 $head_hash{'error'}=0;
 $head_hash{'errorString'}='';
 

--- a/snmp/zfs-freebsd
+++ b/snmp/zfs-freebsd
@@ -243,7 +243,7 @@ while ( defined( $pools[$pools_int] ) ) {
 	$pool =~ s/\%//g;
 	$pool =~ s/\,([0-1\.]*)x\,/,$1,/;
 
-	( $newPool{name}, $newPool{size}, $newPool{alloc}, $newPool{free}, $newPool{expandsz}, $newPool{frag}, $newPool{cap}, $newPool{dedup} )=split(/\,/, $pool);
+	( $newPool{name}, $newPool{size}, $newPool{alloc}, $newPool{free}, $newPool{ckpoint}, $newPool{expandsz}, $newPool{frag}, $newPool{cap}, $newPool{dedup}, $newPool{health} )=split(/\,/, $pool);
 
 	push(@toShoveIntoJSON, \%newPool);
 


### PR DESCRIPTION
FreeBSD introduced a CKPOINT column with zpool list -pH, broke the script.

This is my pool:
```
NAME    SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
zroot  9.06T  7.41T  1.65T        -         -     3%    81%  1.00x  ONLINE  -

```
Incorrect output:

`"pools":[{"size":"9964324126720","expandsz":"0","cap":"3","free":"1818060382208","name":"zroot","frag":"-","alloc":"8146263744512","dedup":"81"}]
`

After the patch:

`"pools":[{"name":"zroot","size":"9964324126720","dedup":"1.00","free":"1818115784704","alloc":"8146208342016","cap":"81","ckpoint":"0","frag":"3","expandsz":"0"}]`