### PR TITLE
Added SAS Drive Wrapping

### DIFF
--- a/snmp/smart
+++ b/snmp/smart
@@ -339,7 +339,41 @@ foreach my $line ( @disks ){
 				$IDs{$id}=$temp;
 			}
 
+
+            
+
 		}
+
+        # SAS Wrapping
+        # Section by Cameron Munroe (munroenet[at]gmail.com)
+
+        # Elements in Grown Defect List.
+        # Marking as 5 Reallocated_Sector_Ct
+
+        if ($line =~ "Elements in grown defect list:"){
+
+            my @lineA=split(/\ /, $line, 10);
+            my $raw=$lineA[5];
+
+            # Reallocated Sector Count ID
+            $IDs{5}=$raw;
+
+        }
+
+        # Current Drive Temperature
+        # Marking as 194 Temperature_Celsius
+
+        if ($line =~ "Current Drive Temperature:"){
+
+            my @lineA=split(/\ /, $line, 10);
+            my $raw=$lineA[3];
+
+            # Temperature C ID
+            $IDs{194}=$raw;
+
+        }
+
+        # End of SAS Wrapper
 
 		$outputAint++;
 	}

--- a/snmp/smart
+++ b/snmp/smart
@@ -338,7 +338,7 @@ foreach my $line ( @disks ){
 				my ( $temp )=split(/\ /, $raw);
 				$IDs{$id}=$temp;
 			}
-			
+
 		}
 
         # SAS Wrapping

--- a/snmp/smart
+++ b/snmp/smart
@@ -338,10 +338,7 @@ foreach my $line ( @disks ){
 				my ( $temp )=split(/\ /, $raw);
 				$IDs{$id}=$temp;
 			}
-
-
-            
-
+			
 		}
 
         # SAS Wrapping


### PR DESCRIPTION
The current SMART agent doesn't work at all with SAS drives. To resolve this I made a wrapper that injects "Elements in Grown Defect List:" into smart "5 Reallocated_Sector_Ct". This seems to be the most logical placement for these errors. Further I have taken drive temps from the SAS output and injected them into "194 Temperature_Celsius". 

I have currently tested this on a couple of SAS drives I have laying around. However, more testing may be required to verify that it works on all SAS drives.

I hope this helps.