### PR TITLE
dhcp-status - seperate binary path configuration from code

### DIFF
--- a/snmp/dhcp-status.sh
+++ b/snmp/dhcp-status.sh
@@ -4,6 +4,7 @@
 # edit your snmpd.conf add the below line and restart snmpd    #
 # extend dhcpstats /opt/dhcp-status.sh                         #
 ################################################################ 
+
 FILE_DHCP='/var/lib/dhcp/db/dhcpd.leases'
 BIN_CAT='/usr/bin/cat'
 BIN_GREP='/usr/bin/grep'
@@ -11,6 +12,12 @@ BIN_TR='/usr/bin/tr'
 BIN_SED='/usr/bin/sed'
 BIN_SORT='/usr/bin/sort'
 BIN_WC='/usr/bin/wc'
+
+CONFIGFILE=dhcp-status.conf
+if [ -f $CONFIGFILE ] ; then
+    . dhcp-status.conf
+fi
+
 DHCP_LEASES='^lease'
 DHCP_ACTIVE='^lease|binding state active'
 DHCP_EXPIRED='^lease|binding state expired'


### PR DESCRIPTION
seperate code from path definition for binaries

**dhcp-status.conf**
```
FILE_DHCP='/var/lib/dhcp/dhcpd.leases'
BIN_CAT='/bin/cat'
BIN_GREP='/bin/grep'
BIN_TR='/usr/bin/tr'
BIN_SED='/bin/sed'
BIN_SORT='/usr/bin/sort'
BIN_WC='/usr/bin/wc'
```

often binary pathes differs from default settings, so only config file has to modified