### PR TITLE
fix dhcp-status configfile declaration

### DIFF
--- a/snmp/dhcp-status.sh
+++ b/snmp/dhcp-status.sh
@@ -13,7 +13,7 @@ BIN_SED='/usr/bin/sed'
 BIN_SORT='/usr/bin/sort'
 BIN_WC='/usr/bin/wc'
 
-CONFIGFILE=dhcp-status.conf
+CONFIGFILE=/etc/snmp/dhcp-status.conf
 if [ -f $CONFIGFILE ] ; then
     . dhcp-status.conf
 fi


### PR DESCRIPTION
Configfile will not be found if snmpd is calling extend, so absolute path declaration is required.