### PR TITLE
fix occasionally random ordering for ups-apc

### DIFF
--- a/snmp/ups-apcups
+++ b/snmp/ups-apcups
@@ -103,9 +103,14 @@ if ( $toReturn{error} == 0 ){
 	# pulls apart the output
 	my @lines=split(/\n/, $apcaccess_output);
 	foreach my $line ( @lines ){
-		my ( $var, $val )=split(/\ *\:\ */, $line, 2);
-		$val=~s/\ .*//;
-		$status{$var}=$val;
+		my ( $var, $val )=split(/\:\ */, $line, 2);
+		if (
+             defined( $var ) && defined( $val )
+			){
+			$var=~s/\ .*//;
+			$val=~s/\ .*//;
+			$status{$var}=$val;
+		}
 	}
 
 	#pull the desired variables from the output
@@ -123,6 +128,7 @@ $toReturn{data}=\%data;
 
 # convert $toReturn to JSON and pretty print if asked to
 my $j=JSON->new;
+$j->canonical(1);
 if ( $opts{p} ){
         $j->pretty(1);
 }

--- a/snmp/ups-apcups
+++ b/snmp/ups-apcups
@@ -84,29 +84,28 @@ my $apcaccess_output=`$apcaccess`;
 $toReturn{error}=$?;
 
 # check for bad exit codes
-if ( $? == -1){
+if ( $? == -1) {
 	$toReturn{errorString}='failed to run apcaccess';
-}
-elsif ($? & 127) {
+} elsif ($? & 127) {
 	$toReturn{errorString}= sprintf "apcaccess died with signal %d, %s coredump\n",
-		($? & 127),  ($? & 128) ? 'with' : 'without';
+	($? & 127),  ($? & 128) ? 'with' : 'without';
 } else {
-		$toReturn{error}=$? >> 8;
-		$toReturn{errorString}="apcaccess exited with ".$toReturn{error};
+	$toReturn{error}=$? >> 8;
+	$toReturn{errorString}="apcaccess exited with ".$toReturn{error};
 }
 
 # if no bad exit codes, we can process $apcaccess_output
-if ( $toReturn{error} == 0 ){
+if ( $toReturn{error} == 0 ) {
 	# holds the found data for the apcupsd status
 	my %status;
 
 	# pulls apart the output
 	my @lines=split(/\n/, $apcaccess_output);
-	foreach my $line ( @lines ){
+	foreach my $line ( @lines ) {
 		my ( $var, $val )=split(/\:\ */, $line, 2);
 		if (
-             defined( $var ) && defined( $val )
-			){
+			defined( $var ) && defined( $val )
+			) {
 			$var=~s/\ .*//;
 			$val=~s/\ .*//;
 			$status{$var}=$val;
@@ -129,11 +128,11 @@ $toReturn{data}=\%data;
 # convert $toReturn to JSON and pretty print if asked to
 my $j=JSON->new;
 $j->canonical(1);
-if ( $opts{p} ){
-        $j->pretty(1);
+if ( $opts{p} ) {
+	$j->pretty(1);
 }
 print $j->encode( \%toReturn );
-if (! $opts{p} ){
-        print "\n";
+if (! $opts{p} ) {
+	print "\n";
 }
 exit 0;


### PR DESCRIPTION
Prompted by https://github.com/librenms/librenms-agent/issues/229

This fixes it some. Values are stabilized, but now need to look into what the poller is doing.

Not exactly sure why it was happening as scoping should of made sure that this did not happen with out erroring.