### PR TITLE
Correct directory check (really a dev / file), and wildcard given name

### DIFF
--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -14,7 +14,7 @@ ERROR_STRING=""
 
 OUTPUT_DATA='['\
 
-if [ -d /dev/md ] ; then
+if [ -e /dev/md* ] ; then
     for RAID in /sys/block/md* ; do
 
         # ignore arrays with no slaves


### PR DESCRIPTION
Correct directory check in mdadm - /dev/md* is not a directory, and also wildcard is needed.

Yell if you have any questions!