### PR TITLE
Split SMART power on hours on h too, not only space

### DIFF
--- a/snmp/smart
+++ b/snmp/smart
@@ -319,7 +319,7 @@ foreach my $line ( @disks ){
 
 			# 9, power on hours
 			if ( $id == 9 ) {
-				my @runtime=split(/\ /, $raw);
+				my @runtime=split(/[\ h]/, $raw);
 				$IDs{$id}=$runtime[0];
 			}
 


### PR DESCRIPTION
Some drives report their `power on hours` (ID 9) as 24789h+02m+03.960s instead of integer hours. We only want the hours, so we split the string at `h` and use the first part.