### PR TITLE
/tmp fix

### DIFF
--- a/agent-local/apache
+++ b/agent-local/apache
@@ -14,7 +14,7 @@
 use LWP::Simple;
 
 $CACHETIME = 30;
-$CACHEFILE = '/tmp/agent-local-apache';
+$CACHEFILE = '/var/cache/librenms/agent-local-apache';
 
 # check for cache file newer CACHETIME seconds ago
 if ( -f $CACHEFILE && time - (stat( $CACHEFILE ))[9] < $CACHETIME) {

--- a/agent-local/dpkg
+++ b/agent-local/dpkg
@@ -4,7 +4,7 @@
 # We cache because it is a 1sec delay, which is painful for the poller
 if [ -x /usr/bin/dpkg-query ]; then
   DATE=$(date +%s)
-  FILE=/tmp/agent-local-dpkg
+  FILE=/var/cache/librenms/agent-local-dpkg
   
   if [ ! -e $FILE ]; then
     dpkg-query -W --showformat='${Status} ${Package} ${Version} ${Architecture} ${Installed-Size}\n'|grep " installed "|cut -d\  -f4- > $FILE

--- a/agent-local/mysql
+++ b/agent-local/mysql
@@ -27,7 +27,7 @@ if (!array_key_exists('SCRIPT_FILENAME', $_SERVER)
 # ============================================================================
 # CONFIGURATION
 # ============================================================================
-# Define MySQL connection constants in config.php. Instead of defining 
+# Define MySQL connection constants in config.php. Instead of defining
 # parameters here, you can define them in another file named the same as this
 # file, with a .cnf extension.
 # ============================================================================
@@ -48,7 +48,7 @@ $heartbeat_server_id = 0;  # Server id to associate with a heartbeat. Leave 0 if
 $heartbeat_table = 'percona.heartbeat'; # db.tbl.
 
 
-$cache_dir  = '/tmp';   # If set, this uses caching to avoid multiple calls.
+$cache_dir  = '/var/cache/librenms';   # If set, this uses caching to avoid multiple calls.
 $timezone   = null;    # If not set, uses the system default.  Example: "UTC"
 $cache_time  = 30;      # How long to cache data.
 
@@ -286,7 +286,7 @@ function ss_get_mysql_stats( $options ) {
    $flags = isset($options['flags']) ? $options['flags'] : $mysql_flags;
    $connection_timeout = isset($options['connection-timeout']) ? $options['connection-timeout'] : $mysql_connection_timeout;
    $heartbeat_server_id = isset($options['server-id']) ? $options['server-id'] : $heartbeat_server_id;
-   
+
    # If there is a port, or if it's a non-standard port, we add ":$port" to the
    # hostname.
    $host_str  = $host.($port != 3306 ? ":$port" : '');
@@ -471,7 +471,7 @@ function ss_get_mysql_stats( $options ) {
          debug("Got nothing from SHOW SLAVE STATUS");
       }
    }
-  
+
    # Get SHOW MASTER STATUS, and add it to the $status array.
    if ($chk_options['master']
          && array_key_exists('log_bin', $status)

--- a/agent-local/nfsstats
+++ b/agent-local/nfsstats
@@ -15,8 +15,8 @@ BIN_GREP='/usr/bin/grep'
 BIN_PASTE='/usr/bin/paste'
 BIN_RM='/usr/bin/rm'
 BIN_MV='/usr/bin/mv'
-LOG_OLD='/tmp/nfsstats_old'
-LOG_NEW='/tmp/nfsstats_new'
+LOG_OLD='/var/cache/librenms/nfsstats_old'
+LOG_NEW='/var/cache/librenms/nfsstats_new'
 
 $BIN_NFSSTAT -$CFG_NFSVER -n -l | $BIN_TR -s " " | $BIN_CUT -d ' ' -f 5 | $BIN_GREP -v '^$' > $LOG_NEW 2>&1
 

--- a/agent-local/rpm
+++ b/agent-local/rpm
@@ -4,7 +4,7 @@
 # We cache because it is a 1sec delay, which is painful for the poller
 if [ -x /bin/rpm ]; then
   DATE=$(date +%s)
-  FILE=/tmp/agent-local-rpm
+  FILE=/var/cache/librenms/agent-local-rpm
   if [ ! -e $FILE ]; then
     /bin/rpm -q --all --queryformat '%{N} %{V} %{R} %{ARCH} %{SIZE}\n' > $FILE
   fi

--- a/snmp/apache-stats
+++ b/snmp/apache-stats
@@ -14,7 +14,7 @@
 use LWP::Simple;
 
 $CACHETIME = 30;
-$CACHEFILE = '/tmp/snmp-cache-apache';
+$CACHEFILE = '/var/cache/librenms/snmp-cache-apache';
 
 # check for cache file newer CACHETIME seconds ago
 if ( -f $CACHEFILE && time - (stat( $CACHEFILE ))[9] < $CACHETIME) {

--- a/snmp/apache-stats.py
+++ b/snmp/apache-stats.py
@@ -19,7 +19,7 @@
 #
 
 CACHETIME = 30
-CACHEFILE = '/tmp/apache-snmp'
+CACHEFILE = '/var/cache/librenms/apache-snmp'
 
 # check for cache file newer CACHETIME seconds ago
 import os

--- a/snmp/mysql
+++ b/snmp/mysql
@@ -27,7 +27,7 @@ if (!array_key_exists('SCRIPT_FILENAME', $_SERVER)
 # ============================================================================
 # CONFIGURATION
 # ============================================================================
-# Define MySQL connection constants in config.php. Instead of defining 
+# Define MySQL connection constants in config.php. Instead of defining
 # parameters here, you can define them in another file named the same as this
 # file, with a .cnf extension.
 # ============================================================================
@@ -49,7 +49,7 @@ $heartbeat_utc = FALSE;    # Whether pt-heartbeat is run with --utc option.
 $heartbeat_server_id = 0;  # Server id to associate with a heartbeat. Leave 0 if no preference.
 $heartbeat_table = 'percona.heartbeat'; # db.tbl.
 
-$cache_dir  = '/tmp';   # If set, this uses caching to avoid multiple calls.
+$cache_dir  = '/var/cache/librenms';   # If set, this uses caching to avoid multiple calls.
 $timezone   = null;    # If not set, uses the system default.  Example: "UTC"
 $cache_time  = 30;      # How long to cache data.
 
@@ -289,7 +289,7 @@ function ss_get_mysql_stats( $options ) {
    $flags = isset($options['flags']) ? $options['flags'] : $mysql_flags;
    $connection_timeout = isset($options['connection-timeout']) ? $options['connection-timeout'] : $mysql_connection_timeout;
    $heartbeat_server_id = isset($options['server-id']) ? $options['server-id'] : $heartbeat_server_id;
-   
+
    # If there is a port, or if it's a non-standard port, we add ":$port" to the
    # hostname.
    $host_str  = $host.($port != 3306 ? ":$port" : '');
@@ -474,7 +474,7 @@ function ss_get_mysql_stats( $options ) {
          debug("Got nothing from SHOW SLAVE STATUS");
       }
    }
-  
+
    # Get SHOW MASTER STATUS, and add it to the $status array.
    if ($chk_options['master']
          && array_key_exists('log_bin', $status)

--- a/snmp/nfs-stats.sh
+++ b/snmp/nfs-stats.sh
@@ -12,9 +12,9 @@ BIN_TR='/usr/bin/tr'
 BIN_PASTE='/usr/bin/paste'
 BIN_RM='/usr/bin/rm'
 BIN_MV='/usr/bin/mv'
-LOG_OLD='/tmp/nfsio_old'
-LOG_NEW='/tmp/nfsio_new'
-LOG_FIX='/tmp/nfsio_fix'
+LOG_OLD='/var/cache/librenms/nfsio_old'
+LOG_NEW='/var/cache/librenms/nfsio_new'
+LOG_FIX='/var/cache/librenms/nfsio_fix'
 
 #get reply cache (rc - values: hits, misses, nocache)
 $BIN_CAT $CFG_NFSFILE | $BIN_SED -n 1p | $BIN_AWK '{print $2,$3,$4}' | $BIN_TR " " "\n" > $LOG_NEW

--- a/snmp/nfs-stats.sh
+++ b/snmp/nfs-stats.sh
@@ -12,9 +12,9 @@ BIN_TR='/usr/bin/tr'
 BIN_PASTE='/usr/bin/paste'
 BIN_RM='/usr/bin/rm'
 BIN_MV='/usr/bin/mv'
-LOG_OLD=`/usr/bin/mktemp`
-LOG_NEW=`/usr/bin/mktemp`
-LOG_FIX=`/usr/bin/mktemp`
+LOG_OLD='/tmp/nfsio_old'
+LOG_NEW='/tmp/nfsio_new'
+LOG_FIX='/tmp/nfsio_fix'
 
 #get reply cache (rc - values: hits, misses, nocache)
 $BIN_CAT $CFG_NFSFILE | $BIN_SED -n 1p | $BIN_AWK '{print $2,$3,$4}' | $BIN_TR " " "\n" > $LOG_NEW

--- a/snmp/nfs-stats.sh
+++ b/snmp/nfs-stats.sh
@@ -12,9 +12,9 @@ BIN_TR='/usr/bin/tr'
 BIN_PASTE='/usr/bin/paste'
 BIN_RM='/usr/bin/rm'
 BIN_MV='/usr/bin/mv'
-LOG_OLD='/tmp/nfsio_old'
-LOG_NEW='/tmp/nfsio_new'
-LOG_FIX='/tmp/nfsio_fix'
+LOG_OLD=`/usr/bin/mktemp`
+LOG_NEW=`/usr/bin/mktemp`
+LOG_FIX=`/usr/bin/mktemp`
 
 #get reply cache (rc - values: hits, misses, nocache)
 $BIN_CAT $CFG_NFSFILE | $BIN_SED -n 1p | $BIN_AWK '{print $2,$3,$4}' | $BIN_TR " " "\n" > $LOG_NEW

--- a/snmp/powerdns-dnsdist
+++ b/snmp/powerdns-dnsdist
@@ -6,7 +6,7 @@ API_AUTH_USER="admin"
 API_AUTH_PASS=""
 API_URL=""
 API_STATS="jsonstat?command=stats"
-TMP_FILE="/tmp/dnsdist_current.stats"
+TMP_FILE=`/usr/bin/mktemp`
 
 #/ Description: BASH script to get PowerDNS dnsdist stats
 #/ Examples: ./powerdns-dnsdist


### PR DESCRIPTION
One could have the static temp file replaced with mktemp. The temp files being used as caches in the rest have been moved to under /var/cache/librenms. Docs need updated for this.



mktemp

* snmp/powerdns-dnsdist 

/var/cache/librenms

* agent-local/apache
* agent-local/dpkg
* agent-local/nfsstats
* agent-local/rpm
* snmp/apache-stats 
* snmp/apache-stats.py
*  snmp/nfs-stats.sh
