### PR TITLE
Updated named.stats location to be compatible with AppArmor

### DIFF
--- a/snmp/bind
+++ b/snmp/bind
@@ -39,7 +39,7 @@ The variables are as below.
 
     rndc = The path to rndc. Default: /usr/bin/env rndc
     call_rndc = A 0/1 boolean on weather to call rndc stats. Suggest to set to 0 if using netdata. Default: 1
-    stats_file = The path to the named stats file. Default: /var/run/named/stats
+    stats_file = The path to the named stats file. Default: /var/cache/bind/named.stats
     agent = A 0/1 boolean for if this is being used as a LibreNMS agent or not. Default: 0
     zero_stats = A 0/1 boolean for if the stats file should be zeroed first. Default: 0 (1 if guessed)
 
@@ -53,7 +53,7 @@ it should be.
 ##
 my $call_rndc=1;
 my $rndc='/usr/bin/env rndc';
-my $stats_file='/var/run/named/stats';
+my $stats_file='/var/cache/bind/named.stats';
 my $zero_stats=0;
 my $agent=0;
 my $missing=0;
@@ -98,7 +98,11 @@ if ( defined( $opts{g} ) ){
 		# a more sane location
 		$stats_file="# This is the the path to the named stats file.\n".
 			'stats_file='.$stats_file."\n";
-	}elsif( -f '/etc/bind/named.stats' ){
+	}elsif( -f '/var/run/named/stats' ){
+		# this is if the person using the old suggested config in the LibreNMS docs
+		$stats_file="# This is the the path to the named stats file.\n".
+			"stats_file=/var/run/named/stats\n";
+	}}elsif( -f '/etc/bind/named.stats' ){
 		# this is if the person using the old suggested config in the LibreNMS docs
 		$stats_file="# This is the the path to the named stats file.\n".
 			"stats_file=/etc/bind/named.stats\n";


### PR DESCRIPTION
After upgrading a Debian Stretch server to Buster, there was a problem with the BIND service due to AppArmor preventing the service from writing to /var/run/named/

Perhaps we could ask the maintainer to add this location to the profile, but looking at the current profile included with bind9. I've updated the _bind_ snmp script to work with previous default and the new default.

dpkg -S /etc/apparmor.d/usr.sbin.named
bind9: /etc/apparmor.d/usr.sbin.named

https://downloads.isc.org/isc/bind9/cur/9.14/doc/arm/Bv9ARM.pdf
page 80 - statistics-file
Suggests named.stats would be in the servers current dir (/etc/bind/?) but AppArmor only grants read access

The named apparmor profile lists /var/lib/bind/ and /var/cache/bind/ as having rw access
  ```
# /etc/bind should be read-only for bind
  # /var/lib/bind is for dynamically updated zone (and journal) files.
  # /var/cache/bind is for slave/stub data, since we're not the origin of it.
  # See /usr/share/doc/bind9/README.Debian.gz
  /etc/bind/** r,
  /var/lib/bind/** rw,
  /var/lib/bind/ rw,
  /var/cache/bind/** lrw,
  /var/cache/bind/ rw,
```