### PR TITLE
Added CPU Details

### DIFF
--- a/snmp/detailedcpu.sh
+++ b/snmp/detailedcpu.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# This is to get Detailed CPU stats into LibreNMS. 
-# The goal being to track Steal and IOWait in shared virtual enviornements. 
+# This is to get Detailed CPU stats into LibreNMS.
+# The goal being to track Steal and IOWait in shared virtual enviornements.
 
 # Please make sure you have tail, vmstat, and awk installed.
-# Currently modern kernels beyond 2.6.11 should be supported. 
+# Currently modern kernels beyond 2.6.11 should be supported.
 
 # By Munzy https://github.com/Munzy
 
@@ -22,9 +22,10 @@
 # $16 = IO Wait
 # $17 = CPU Steal
 
+VMSTAT=`vmstat 1 2 | tail -n 1`
 
-vmstat | tail -n 1 |  awk '{print $13}'
-vmstat | tail -n 1 |  awk '{print $14}'
-vmstat | tail -n 1 |  awk '{print $15}'
-vmstat | tail -n 1 |  awk '{print $16}'
-vmstat | tail -n 1 |  awk '{print $17}'
+echo $VMSTAT | awk '{print $13}'
+echo $VMSTAT | awk '{print $14}'
+echo $VMSTAT | awk '{print $15}'
+echo $VMSTAT | awk '{print $16}'
+echo $VMSTAT | awk '{print $17}'

--- a/snmp/detailedcpu.sh
+++ b/snmp/detailedcpu.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This is to get Detailed CPU stats into LibreNMS. 
+# The goal being to track Steal and IOWait in shared virtual enviornements. 
+
+# Please make sure you have tail, vmstat, and awk installed.
+# Currently modern kernels beyond 2.6.11 should be supported. 
+
+# By Munzy https://github.com/Munzy
+
+# vmstat -w
+# procs -----------------------memory---------------------- ---swap-- -----io---- -system-- --------cpu--------
+#  r  b         swpd         free         buff        cache   si   so    bi    bo   in   cs  us  sy  id  wa  st
+#  0  0        18432       348376       256872      3150908    0    0     0     2    1    2   0   0 100   0   0
+#
+# vmstat | tail -n 1 |  awk '{print $13, $14, $15, $16, $17}'
+# 0 0 100 0 0
+
+# $13 = User
+# $14 = System
+# $15 = Idle
+# $16 = IO Wait
+# $17 = CPU Steal
+
+
+vmstat | tail -n 1 |  awk '{print $13}'
+vmstat | tail -n 1 |  awk '{print $14}'
+vmstat | tail -n 1 |  awk '{print $15}'
+vmstat | tail -n 1 |  awk '{print $16}'
+vmstat | tail -n 1 |  awk '{print $17}'


### PR DESCRIPTION
I have long wanted a way to monitor steal time on my VMs. I currently use a lot of VMs on hosting providers such as Linode, Digital Ocean, et cetera. These providers sometimes over-allocate a node to the point of becoming a problem. One way to indicate this issue is CPU Steal climbing beyond a certain percentage. 

https://scoutapm.com/blog/understanding-cpu-steal-time-when-should-you-be-worried

The goal is to allow LibreNMS to track users, system, idle, io wait, and steal numbers so that we can make better decisions on how to improve performance or mitigate performance issues on a VM.
