### PR TITLE
zfs-freebsd - Repair percentage calculation

### DIFF
--- a/snmp/zfs-freebsd
+++ b/snmp/zfs-freebsd
@@ -160,7 +160,7 @@ my $actual_hit_percent = $real_hits / $arc_accesses_total * 100;
 
 my $data_demand_percent = 0;
 if ( $demand_data_total != 0 ){
-	$demand_data_hits /= $demand_data_total * 100;
+	$data_demand_percent = $demand_data_hits / $demand_data_total * 100;
 }
 
 my $data_prefetch_percent=0;

--- a/snmp/zfs-freebsd
+++ b/snmp/zfs-freebsd
@@ -160,7 +160,7 @@ my $actual_hit_percent = $real_hits / $arc_accesses_total * 100;
 
 my $data_demand_percent = 0;
 if ( $demand_data_total != 0 ){
-	$demand_data_hits / $demand_data_total * 100;
+	$demand_data_hits /= $demand_data_total * 100;
 }
 
 my $data_prefetch_percent=0;


### PR DESCRIPTION
When running this script, I get:

Useless use of multiplication (*) in void context at ./zfs-freebsd line 163