### PR TITLE
Fix zfs-freebsd.py Capacity Output

### DIFF
--- a/snmp/zfs-freebsd.py
+++ b/snmp/zfs-freebsd.py
@@ -97,20 +97,20 @@ def main(args):
 		return p.returncode
 	output['pools'] = []
 	fields = ['name', 'size', 'alloc', 'free', 'ckpoint', 'expandsz', 'frag', 'cap', 'dedup']
-        for l in p.stdout.splitlines():
-                p = dict(zip(fields, l.split('\t')))
-                if p['ckpoint'] == '-': 
-                        p['ckpoint'] = 0 
-                if p['expandsz'] == '-':
-                        p['expandsz'] = 0
-                p['frag'] = p['frag'].rstrip('%')
-                if p['frag'] == '-':
-                        p['frag'] = 0
-                p['cap'] = p['cap'].rstrip('%')
-                if p['cap'] == '-':
-                        p['cap'] = 0
-                p['dedup'] = p['dedup'].rstrip('x')
-                output['pools'].append(p)
+	for l in p.stdout.splitlines():
+		p = dict(zip(fields, l.split('\t')))
+		if p['ckpoint'] == '-': 
+			p['ckpoint'] = 0 
+		if p['expandsz'] == '-':
+			p['expandsz'] = 0
+		p['frag'] = p['frag'].rstrip('%')
+		if p['frag'] == '-':
+			p['frag'] = 0
+		p['cap'] = p['cap'].rstrip('%')
+		if p['cap'] == '-':
+			p['cap'] = 0
+		p['dedup'] = p['dedup'].rstrip('x')
+		output['pools'].append(p)
 
 	print(json.dumps(output))
 

--- a/snmp/zfs-freebsd.py
+++ b/snmp/zfs-freebsd.py
@@ -96,16 +96,21 @@ def main(args):
 	if p.returncode != 0:
 		return p.returncode
 	output['pools'] = []
-	fields = ['name', 'size', 'alloc', 'free', 'expandsz', 'frag', 'cap', 'dedup']
-	for l in p.stdout.splitlines():
-		p = dict(zip(fields, l.split('\t')))
-		if p['expandsz'] == '-':
-			p['expandsz'] = 0
-		p['frag'] = p['frag'].rstrip('%')
-		if p['frag'] == '-':
-			p['frag'] = 0
-		p['dedup'] = p['dedup'].rstrip('x')
-		output['pools'].append(p)
+	fields = ['name', 'size', 'alloc', 'free', 'ckpoint', 'expandsz', 'frag', 'cap', 'dedup']
+        for l in p.stdout.splitlines():
+                p = dict(zip(fields, l.split('\t')))
+                if p['ckpoint'] == '-': 
+                        p['ckpoint'] = 0 
+                if p['expandsz'] == '-':
+                        p['expandsz'] = 0
+                p['frag'] = p['frag'].rstrip('%')
+                if p['frag'] == '-':
+                        p['frag'] = 0
+                p['cap'] = p['cap'].rstrip('%')
+                if p['cap'] == '-':
+                        p['cap'] = 0
+                p['dedup'] = p['dedup'].rstrip('x')
+                output['pools'].append(p)
 
 	print(json.dumps(output))
 


### PR DESCRIPTION
'zpool-list -pH' returns capacity as a percentage which needs to be stripped as well as account for null (-) values. Additionally, the output now also includes 'CKPOINT' which needs to be added to the fields array so it splits correctly.