### PR TITLE
Mdadm - Hotspare Count should not go below zero

### DIFF
--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -80,7 +80,7 @@ if [ -d /dev/md ] ; then
         RAID_MISSING_DEVICES=$RAID_MISSING_DEVICES']'
 
         let "RAID_HOTSPARE_COUNT=ALL_DEVICE_COUNT-RAID_DISC_COUNT"
-        if [ $RAID_HOTSPARE_COUNT -lt 0 ]; then
+        if [ $RAID_HOTSPARE_COUNT -lt 0 ] ; then
             RAID_HOTSPARE_COUNT=0
         fi
 

--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -80,6 +80,9 @@ if [ -d /dev/md ] ; then
         RAID_MISSING_DEVICES=$RAID_MISSING_DEVICES']'
 
         let "RAID_HOTSPARE_COUNT=ALL_DEVICE_COUNT-RAID_DISC_COUNT"
+        if [ $RAID_HOTSPARE_COUNT -lt 0 ]; then
+            RAID_HOTSPARE_COUNT=0
+        fi
 
         ARRAY_DATA='{'\
 '"name":"'$RAID_NAME\


### PR DESCRIPTION
Hotspare Count goes below zero if no Hotspare was present and Array is degraded