### PR TITLE
Completely breaks librenms metric collections; perl syntax error

### DIFF
--- a/snmp/zfs-freebsd
+++ b/snmp/zfs-freebsd
@@ -160,7 +160,7 @@ my $actual_hit_percent = $real_hits / $arc_accesses_total * 100;
 
 my $data_demand_percent = 0;
 if ( $demand_data_total != 0 ){
-	$demand_data_hits / $demand_data_total * 100;
+	$data_demand_percent = $demand_data_hits / $demand_data_total * 100;
 }
 
 my $data_prefetch_percent=0;


### PR DESCRIPTION

```Perl error "Useless use of multiplication (*) in void context at /etc/snmp.d/zfs-freebsd line 163."```

Been bagging my head on why extend would not work on FreeBSD with the perl script.  The error getting written to stderr, which was getting into the output, which I assume wasn't being found on the NMS side.

```
[...]
NET-SNMP-EXTEND-MIB::nsExtendOutNumLines."zfs" = INTEGER: 2
NET-SNMP-EXTEND-MIB::nsExtendResult."zfs" = INTEGER: 0
NET-SNMP-EXTEND-MIB::nsExtendOutLine."zfs".1 = STRING: Useless use of multiplication (*) in void context at /etc/snmp.d/zfs-freebsd line 163.
NET-SNMP-EXTEND-MIB::nsExtendOutLine."zfs".2 = STRING: {\"data\":{\"target_size_arat\":0.82645131363 [ ... ]
[...]
```