### PR TITLE
Fix apache-stats.sh

### DIFF
--- a/snmp/apache-stats.sh
+++ b/snmp/apache-stats.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # This script produces LibreNMS apache-stats output.  The only dependency is curl.
 


### PR DESCRIPTION
Ubuntu is using dash as the default system shell but the script requires bash.

This fixes the error message apache-stats.sh 13: Syntax error: "(" unexpected