### PR TITLE
Update gpsd

### DIFF
--- a/agent-local/gpsd
+++ b/agent-local/gpsd
@@ -4,8 +4,8 @@
 $server = 'localhost';
 $port = 2947;
 
-set_time_limit(4);
-ini_set('max_execution_time', 4);
+set_time_limit(6);
+ini_set('max_execution_time', 6);
 
 
 $sock = @fsockopen($server, $port, $errno, $errstr, 2);


### PR DESCRIPTION
4s max time limit was causing some timeouts, especially given the two 1s sleeps. Especially with a lot of sentences coming back from the GPS chip it was probably not enough to always catch the right variables.