### PR TITLE
Remove absolute exe for powerdns + use python3

### DIFF
--- a/agent-local/powerdns
+++ b/agent-local/powerdns
@@ -1,16 +1,17 @@
-#!/usr/bin/env python
-
+#!/usr/bin/env python3
 from subprocess import Popen, PIPE
 
-vars = [ 'corrupt-packets', 'deferred-cache-inserts', 'deferred-cache-lookup',
-'latency', 'packetcache-hit', 'packetcache-miss', 'packetcache-size',
-'qsize-q', 'query-cache-hit', 'query-cache-miss', 'recursing-answers',
-'recursing-questions', 'servfail-packets', 'tcp-answers', 'tcp-queries',
-'timedout-packets', 'udp-answers', 'udp-queries', 'udp4-answers',
-'udp4-queries', 'udp6-answers', 'udp6-queries' ]
+kvars = [ 
+    'corrupt-packets', 'deferred-cache-inserts', 'deferred-cache-lookup',
+    'latency', 'packetcache-hit', 'packetcache-miss', 'packetcache-size',
+    'qsize-q', 'query-cache-hit', 'query-cache-miss', 'recursing-answers',
+    'recursing-questions', 'servfail-packets', 'tcp-answers', 'tcp-queries',
+    'timedout-packets', 'udp-answers', 'udp-queries', 'udp4-answers',
+    'udp4-queries', 'udp6-answers', 'udp6-queries'
+]
 
 rvars = {}
-cmd = ['/usr/bin/pdns_control', 'show', '*']
+cmd = ['pdns_control', 'show', '*']
 
 for l in Popen(cmd, stdout=PIPE).communicate()[0].decode().rstrip().split(','):
     v = l.split('=')
@@ -19,5 +20,6 @@ for l in Popen(cmd, stdout=PIPE).communicate()[0].decode().rstrip().split(','):
 
 print("<<<app-powerdns>>>")
 
-for k in vars:
+for k in kvars:
     print(rvars[k])
+

--- a/agent-local/powerdns-recursor
+++ b/agent-local/powerdns-recursor
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import json, subprocess
 from subprocess import Popen, PIPE
 


### PR DESCRIPTION
As per the title, I've removed the absolute path for the `pdns_control` executable for the `powerdns` agent, since it's un-necessary and causes problems when the binary is in a different location. Along with some other improvements:

 - `agent-local/powerdns`
    - Replaced the absolute path `/usr/bin/pdns_control` with `pdns_control`, since pdns_control can also be in `/usr/sbin` or `/usr/local/bin`.
      Python can find the executable using PATH just fine.
    - Changed `vars` to `kvars` to avoid conflicting with the reserved `vars` Python symbol
    - Changed shebang to use `python3` instead of `python` - as Python 2 is EOL.

 - `agent-local/powerdns-recursor`
    - Changed shebang to use `/usr/bin/env` instead of a hardcoded path to Python
    - Changed shebang to use `python3` instead of `python` - as Python 2 is EOL.

**NOTE:** As per https://pythonclock.org/ - Python 2 is end-of-life, and is no longer included by default on modern Linux distros,
along with macOS (OS X).

I would recommend adjusting all Python-based agents to use Python 3 by default, instead of Python 2.