### PR TITLE
Fix up smart script to also parse some values from NVMe drives

### DIFF
--- a/snmp/smart
+++ b/snmp/smart
@@ -283,105 +283,132 @@ foreach my $line ( @disks ){
 			  '233'=>'null',
 			  '9'=>'null',
 	);
+    
+    my @outputA;
 
-    my @outputA=split( /\n/, $output );
-	my $outputAint=0;
-	while ( defined($outputA[$outputAint]) ) {
-		my $line=$outputA[$outputAint];
-		$line=~s/^ +//;
-		$line=~s/  +/ /g;
+	if($output =~ /NVMe Log/)
+    {
+        # we have an NVMe drive with annoyingly different output
+        my %mappings=(
+            'Temperature' => 194,
+            'Power Cycles' => 12,
+            'Power On Hours' => 9,
+        );
+        foreach(split(/\n/, $output ))
+        {
+            if(/:/)
+            {
+                my ($key, $val) = split(/:/);
+                $val =~ s/^\s+|\s+$|\D+//g;
+                if(exists($mappings{$key}))
+                {
+                    $IDs{$mappings{$key}} = $val;       
+                }
+            }
+        }
 
-		if ( $line =~ /^[0123456789]+ / ) {
-			my @lineA=split(/\ /, $line, 10);
-			my $raw=$lineA[9];
-			my $id=$lineA[0];
+    }
+    else
+    {
+    	@outputA=split( /\n/, $output );
+		my $outputAint=0;
+		while ( defined($outputA[$outputAint]) ) {
+			my $line=$outputA[$outputAint];
+			$line=~s/^ +//;
+			$line=~s/  +/ /g;
 
-			# Crucial SSD
-			# 202, Percent_Lifetime_Remain, same as 231, SSD Life Left
-			if ( $id == 202 ) {
-					$IDs{231}=$raw;
-			}
+			if ( $line =~ /^[0123456789]+ / ) {
+				my @lineA=split(/\ /, $line, 10);
+				my $raw=$lineA[9];
+				my $id=$lineA[0];
 
-			# single int raw values
-			if (
-				( $id == 5 ) ||
-				( $id == 10 ) ||
-				( $id == 173 ) ||
-				( $id == 177 ) ||
-				( $id == 183 ) ||
-				( $id == 184 ) ||
-				( $id == 187 ) ||
-				( $id == 196 ) ||
-				( $id == 197 ) ||
-				( $id == 198 ) ||
-				( $id == 199 ) ||
-				( $id == 231 ) ||
-				( $id == 233 )
-				) {
-				$IDs{$id}=$raw;
-			}
-
-			# 9, power on hours
-			if ( $id == 9 ) {
-				my @runtime=split(/[\ h]/, $raw);
-				$IDs{$id}=$runtime[0];
-			}
-
-			# 188, Command_Timeout
-			if ( $id == 188 ) {
-				my $total=0;
-				my @rawA=split( /\ /, $raw );
-				my $rawAint=0;
-				while ( defined( $rawA[$rawAint] ) ) {
-					$total=$total+$rawA[$rawAint];
-					$rawAint++;
+				# Crucial SSD
+				# 202, Percent_Lifetime_Remain, same as 231, SSD Life Left
+				if ( $id == 202 ) {
+						$IDs{231}=$raw;
 				}
-				$IDs{$id}=$total;
+
+				# single int raw values
+				if (
+					( $id == 5 ) ||
+					( $id == 10 ) ||
+					( $id == 173 ) ||
+					( $id == 177 ) ||
+					( $id == 183 ) ||
+					( $id == 184 ) ||
+					( $id == 187 ) ||
+					( $id == 196 ) ||
+					( $id == 197 ) ||
+					( $id == 198 ) ||
+					( $id == 199 ) ||
+					( $id == 231 ) ||
+					( $id == 233 )
+					) {
+					$IDs{$id}=$raw;
+				}
+
+				# 9, power on hours
+				if ( $id == 9 ) {
+					my @runtime=split(/[\ h]/, $raw);
+					$IDs{$id}=$runtime[0];
+				}
+
+				# 188, Command_Timeout
+				if ( $id == 188 ) {
+					my $total=0;
+					my @rawA=split( /\ /, $raw );
+					my $rawAint=0;
+					while ( defined( $rawA[$rawAint] ) ) {
+						$total=$total+$rawA[$rawAint];
+						$rawAint++;
+					}
+					$IDs{$id}=$total;
+				}
+
+				# 190, airflow temp
+				# 194, temp
+				if (
+					( $id == 190 ) ||
+					( $id == 194 )
+					) {
+					my ( $temp )=split(/\ /, $raw);
+					$IDs{$id}=$temp;
+				}
 			}
 
-			# 190, airflow temp
-			# 194, temp
-			if (
-				( $id == 190 ) ||
-				( $id == 194 )
-				) {
-				my ( $temp )=split(/\ /, $raw);
-				$IDs{$id}=$temp;
-			}
+    	    # SAS Wrapping
+    	    # Section by Cameron Munroe (munroenet[at]gmail.com)
+
+    	    # Elements in Grown Defect List.
+    	    # Marking as 5 Reallocated_Sector_Ct
+
+    	    if ($line =~ "Elements in grown defect list:"){
+
+    	        my @lineA=split(/\ /, $line, 10);
+    	        my $raw=$lineA[5];
+
+    	        # Reallocated Sector Count ID
+    	        $IDs{5}=$raw;
+
+    	    }
+
+    	    # Current Drive Temperature
+    	    # Marking as 194 Temperature_Celsius
+
+    	    if ($line =~ "Current Drive Temperature:"){
+
+    	        my @lineA=split(/\ /, $line, 10);
+    	        my $raw=$lineA[3];
+
+    	        # Temperature C ID
+    	        $IDs{194}=$raw;
+
+    	    }
+
+    	    # End of SAS Wrapper
+
+			$outputAint++;
 		}
-
-        # SAS Wrapping
-        # Section by Cameron Munroe (munroenet[at]gmail.com)
-
-        # Elements in Grown Defect List.
-        # Marking as 5 Reallocated_Sector_Ct
-
-        if ($line =~ "Elements in grown defect list:"){
-
-            my @lineA=split(/\ /, $line, 10);
-            my $raw=$lineA[5];
-
-            # Reallocated Sector Count ID
-            $IDs{5}=$raw;
-
-        }
-
-        # Current Drive Temperature
-        # Marking as 194 Temperature_Celsius
-
-        if ($line =~ "Current Drive Temperature:"){
-
-            my @lineA=split(/\ /, $line, 10);
-            my $raw=$lineA[3];
-
-            # Temperature C ID
-            $IDs{194}=$raw;
-
-        }
-
-        # End of SAS Wrapper
-
-		$outputAint++;
 	}
 
 	#get the selftest logs


### PR DESCRIPTION
Noticed that the temperature etc values from NVMe drives were not being parsed. This change adds some simple functionality to track temperature and also power cycles/on hours.

Fixes  #285 