### PR TITLE
Use sh in ups-nut.sh shebang

### DIFF
--- a/snmp/ups-nut.sh
+++ b/snmp/ups-nut.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 ################################################################
 # Instructions:                                                #
 # 1. copy this script to /etc/snmp/ and make it executable:    #


### PR DESCRIPTION
since the `ups-nut.sh` script is not using any bash specific syntax.
This change removes unneeded dependency on bash.