### PR TITLE
Fix missing compatibility to Pi-hole V5 API (minimal changes)

### DIFF
--- a/snmp/pi-hole
+++ b/snmp/pi-hole
@@ -71,10 +71,10 @@ debug() {
 exportdata() {
 	# domains_being_blocked / dns_query_total / ads_blocked_today / ads_percentage_today
 	# unique_domains / queries_forwarded / queries_cached
-	GET_STATS=$(curl -s $API_URL$URL_READ_ONLY | jq '.[]')
+	GET_STATS=$(curl -s $API_URL$URL_READ_ONLY | jq '.domains_being_blocked, .dns_queries_today, .ads_blocked_today, .ads_percentage_today, .unique_domains, .queries_forwarded, .queries_cached')
 	echo $GET_STATS | tr " " "\n"
 	# A / AAAA / PTR / SRV
-	GET_QUERY_TYPE=$(curl -s $API_URL$URL_QUERY_TYPE$API_AUTH_KEY | jq '.[][]')
+	GET_QUERY_TYPE=$(curl -s $API_URL$URL_QUERY_TYPE$API_AUTH_KEY | jq '.[]["A (IPv4)", "AAAA (IPv6)", "PTR", "SRV"]')
 	echo $GET_QUERY_TYPE | tr " " "\n"
 }
 


### PR DESCRIPTION
To minimize the impact of future API changes in terms of data order or additional data being appended, required elements are selected directly with the "jq" tool in the expected order.

In theory this change should be backwards compatible to the previous version of the Pi-hole API, but I don't have access to an older version (V4 API) to test it.