### PR TITLE
Update distro to support BeagleBoard

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -64,6 +64,10 @@ elif [ "${OS}" = "Linux" ] ; then
       DIST="${DIST}/PVE `/usr/bin/pveversion | cut -d '/' -f 2`"
       IGNORE_OS_RELEASE=1
     fi
+    if [ -f /etc/dogtag ]; then
+      DIST=`cat /etc/dogtag`
+      IGNORE_OS_RELEASE=1
+    fi
     
   elif [ -f /etc/gentoo-release ] ; then
     DIST="Gentoo"


### PR DESCRIPTION
Add support for BeagleBoard (distro) - checks BeagleBoard signature, if existing (in /etc/dogtag). Example of that file,
```
cat /etc/dogtag
BeagleBoard.org Debian Buster IoT TIDL Image 2020-04-06
```