### PR TITLE
Add snmp script for BeagleBoard Temperature Sensors

### DIFF
--- a/snmp/beagleboard.sh
+++ b/snmp/beagleboard.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat /sys/devices/virtual/thermal/thermal_zone*/temp


### PR DESCRIPTION
Add a new snmp script, similar to Raspberry Pi sensors, but this is for BeagleBoard. Output from the command (example),
```
$ beagleboard.sh
40200
41400
40600
39800
41000
```

Thanks!