### PR TITLE
Fix distro for FreeBSD/FreeNAS

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -139,9 +139,11 @@ elif [ "${OS}" = "Darwin" ] ; then
   fi
 
 elif [ "${OS}" = "FreeBSD" ] ; then
-  DIST=$(cat /etc/version | cut -d'-' -f 1)
-  if [ "${DIST}" = "FreeNAS" ]; then
-    OSSTR=`cat /etc/version | cut -d' ' -f 1`
+  if [ -f /etc/version ] ; then
+    DIST=$(cat /etc/version | cut -d'-' -f 1)
+    if [ "${DIST}" = "FreeNAS" ]; then
+      OSSTR=`cat /etc/version | cut -d' ' -f 1`
+    fi
   else
     OSSTR=`/usr/bin/uname -mior`
   fi


### PR DESCRIPTION
Check if /etc/version file present for FreeBSD OS

Without fix on FreeBSD: ./distro
cat: /etc/version: No such file or directory
FreeBSD 12.1-RELEASE-p5 amd64 GENERIC