### PR TITLE
Adding opensips3.X + version support

### DIFF
--- a/snmp/opensip3-stats.sh
+++ b/snmp/opensip3-stats.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Author: Sharad Kumar <skumar@securevoip.io>
+# This script is for OpenSIPS 3.X + version
+
+total_memory=$(opensips-cli -x mi  get_statistics total_size | awk '/shmem:total_size/ { gsub(/[",]/,""); print "Total Memory="  $2}')
+used_memory=$(opensips-cli -x mi  get_statistics real_used_size | awk '/shmem:real_used_size/ { gsub(/[",]/,""); print "Used Memory=" $2}')
+free_memory=$(opensips-cli -x mi  get_statistics free_size | awk '/shmem:free_size/ { gsub(/[",]/,""); print "Free Memory=" $2}')
+load_average=$(ps -C opensips -o %cpu | awk '{sum += $1} END {print "Load Average=" sum}')
+total_files=$(lsof -c opensips | wc -l)
+
+
+echo $total_memory
+echo $used_memory
+echo $free_memory
+echo $load_average
+echo "Open files="$total_files
+
+exit
+

--- a/snmp/opensips-stats.sh
+++ b/snmp/opensips-stats.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Author: Sharad Kumar <skumar@securevoip.io>
+# This script is for OpenSIPS 2.X + version
 
 total_memory=$(opensipsctl fifo get_statistics total_size | awk '{print "Total Memory=" $2}')
 used_memory=$(opensipsctl fifo get_statistics real_used_size | awk '{print "Used Memory=" $2}')


### PR DESCRIPTION
Hey guys, 

The existing opensips-stats.sh script in SNMP directory is for OpenSIPS2.X version. I have created a separate file for OpenSIPS3.X and will also update the application installation docs too. 

The output of the newly added script is the same as the previous one so nothing gonna break on librenms side. 


Thank you 