### PR TITLE
Bugfix freeradius.sh

### DIFF
--- a/snmp/freeradius.sh
+++ b/snmp/freeradius.sh
@@ -10,9 +10,9 @@ RADIUS_SERVER='localhost'
 RADIUS_PORT='18121'
 RADIUS_KEY='adminsecret'
 
-if [ -f $CONFIGFILE ]; do
+if [ -f $CONFIGFILE ]; then
     . $CONFIGFILE
-done
+fi
 
 # Default radclient access request, shouldn't need to be changed
 RADIUS_STATUS_CMD='Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 31, Response-Packet-Type = Access-Accept'


### PR DESCRIPTION
Fix a syntax error. 

BTW I would prefer to consequently use no extension (some have):
"
Executables should have no extension (strongly preferred) or a .sh extension. Libraries must have a .sh extension and should not be executable.

It is not necessary to know what language a program is written in when executing it and shell doesn’t require an extension so we prefer not to use one for executables
" from 
https://google.github.io/styleguide/shellguide.html