### PR TITLE
Fix STDERR output corrupting json output in mdadm app

### DIFF
--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -22,7 +22,7 @@ if $LS /dev/md?* 1> /dev/null 2>&1 ; then
         RAID="/sys/block/"$($BASENAME $($REALPATH $ARRAY_BLOCKDEVICE))
 
         # ignore arrays with no slaves
-        if [ -z "$($LS -1 $RAID/slaves)" ] ; then
+        if [ -z "$($LS -1 $RAID/slaves 2> /dev/null)" ] ; then
             continue
         fi
         # ignore "non existing" arrays


### PR DESCRIPTION
When checking if arrays have slaves, the mdadm script, does an  ls/$LS of the device to see if it exists.
This $LS throws an error to STDERR if it does not match.
This output is caught by snmp and corrupts the json output