### PR TITLE
Add chrony support

### DIFF
--- a/snmp/chrony
+++ b/snmp/chrony
@@ -3,12 +3,22 @@ import json
 import shlex
 import subprocess
 
+VERSION = 1
+
 def proc_err(cmd, proc):
     # output process error and first line of error code
     return "{}{}".format(
         subprocess.CalledProcessError(proc.returncode, cmd, proc.stderr),
         " ({})".format(proc.stderr.splitlines()[0]) if proc.stderr.splitlines() else ""
     )
+
+def print_data(data, error, error_msg):
+    print(json.dumps({
+        'data': data,
+        'error': error,
+        'errorString': error_msg,
+        'version': VERSION
+    }))
 
 def main(args):
     CSV_HEADERS = {
@@ -55,12 +65,14 @@ def main(args):
         'tracking': {},
         'sources': []
     }
+    ERROR = False
+    ERROR_MSG = ''
 
     # get and set tracking data
     rc, tracking = subprocess.getstatusoutput('chronyc -c tracking')
     if rc != 0:
-        print ("Error getting tracking:", tracking)
-        exit(1)
+        print_data(DATA, rc, tracking)
+        return 1
     tracking = tracking.split(',')
     for i in range(0, len(CSV_HEADERS['tracking'])):
         DATA['tracking'][CSV_HEADERS['tracking'][i]] = tracking[i]
@@ -68,13 +80,13 @@ def main(args):
     # get sources + sourcestats data
     rc, sources = subprocess.getstatusoutput('chronyc -c sources')
     if rc != 0:
-        print ("Error getting sources:", tracking)
-        exit(1)
+        print_data(DATA, rc, sources)
+        return 1
     sources = sources.split('\n')
     rc, sourcestats = subprocess.getstatusoutput('chronyc -c sourcestats')
     if rc != 0:
-        print ("Error getting sourcestats:", tracking)
-        exit(1)
+        print_data(DATA, rc, sourcestats)
+        return 1
     sourcestats = sourcestats.split('\n')
 
     # mix sources and sourcestats
@@ -90,7 +102,7 @@ def main(args):
 
         DATA['sources'].append(data)
 
-    print(json.dumps(DATA))
+    print_data(DATA, ERROR, ERROR_MSG)
 
     return 0
 

--- a/snmp/chrony
+++ b/snmp/chrony
@@ -45,7 +45,7 @@ def main(args):
             'stratum',
             'polling_rate',
             'reachability',
-            'lastrx',
+            'last_rx',
             'adjusted_offset',
             'measured_offset',
             'estimated_error'

--- a/snmp/chrony
+++ b/snmp/chrony
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+import json
+import shlex
+import subprocess
+
+def proc_err(cmd, proc):
+    # output process error and first line of error code
+    return "{}{}".format(
+        subprocess.CalledProcessError(proc.returncode, cmd, proc.stderr),
+        " ({})".format(proc.stderr.splitlines()[0]) if proc.stderr.splitlines() else ""
+    )
+
+def main(args):
+    CSV_HEADERS = {
+        'tracking': [
+            'reference_name',
+            'reference_type',
+            'stratum',
+            'reference_time',
+            'system_time',
+            'last_offset',
+            'rms_offset',
+            'frequency',
+            'residual_frequency',
+            'skew',
+            'root_delay',
+            'root_dispersion',
+            'update_interval',
+            'leap_status',
+        ],
+        'sources': [
+            'source_mode',
+            'source_state',
+            'source_name',
+            'stratum',
+            'polling_rate',
+            'reachability',
+            'lastrx',
+            'adjusted_offset',
+            'measured_offset',
+            'estimated_error'
+        ],
+        'sourcestats': [
+            'source_name',
+            'number_samplepoints',
+            'number_runs',
+            'span',
+            'frequency',
+            'frequency_skew',
+            'offset',
+            'stddev',
+        ]
+    }
+    DATA = {
+        'tracking': {},
+        'sources': []
+    }
+
+    # get and set tracking data
+    rc, tracking = subprocess.getstatusoutput('chronyc -c tracking')
+    if rc != 0:
+        print ("Error getting tracking:", tracking)
+        exit(1)
+    tracking = tracking.split(',')
+    for i in range(0, len(CSV_HEADERS['tracking'])):
+        DATA['tracking'][CSV_HEADERS['tracking'][i]] = tracking[i]
+
+    # get sources + sourcestats data
+    rc, sources = subprocess.getstatusoutput('chronyc -c sources')
+    if rc != 0:
+        print ("Error getting sources:", tracking)
+        exit(1)
+    sources = sources.split('\n')
+    rc, sourcestats = subprocess.getstatusoutput('chronyc -c sourcestats')
+    if rc != 0:
+        print ("Error getting sourcestats:", tracking)
+        exit(1)
+    sourcestats = sourcestats.split('\n')
+
+    # mix sources and sourcestats
+    for i in range(0, len(sources)):
+        source = sources[i].split(',')
+        stats = sourcestats[i].split(',')
+        data = {}
+
+        for j in range(0, len(CSV_HEADERS['sources'])):
+            data[CSV_HEADERS['sources'][j]] = source[j]
+        for j in range(0, len(CSV_HEADERS['sourcestats'])):
+            data[CSV_HEADERS['sourcestats'][j]] = stats[j]
+
+        DATA['sources'].append(data)
+
+    print(json.dumps(DATA))
+
+    return 0
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
I am preparing a PR on the frontend side of LibreNMS to add support for chrony, and so this is just a probing script that outputs a JSON containing information from the following `chronyc` subcommands:

- `tracking`
- `sources`
- `sourcestats`

A sample output:

```
{"tracking": {"reference_name": "50505300", "reference_type": "PPS", "stratum": "1", "reference_time": "1611776272.200448744", "system_time": "-0.000000023", "last_offset": "0.000000019", "rms_offset": "0.000000027", "frequency": "-3.950", "residual_frequency": "0.000", "skew": "0.002", "root_delay": "0.000000001", "root_dispersion": "0.000004171", "update_interval": "4.0", "leap_status": "Normal"}, "sources": [{"source_mode": "#", "source_state": "*", "source_name": "PPS", "stratum": "0", "polling_rate": "2", "reachability": "377", "lastrx": "4", "adjusted_offset": "0.000000175", "measured_offset": "0.000000193", "estimated_error": "0.000000299", "number_samplepoints": "42", "number_runs": "23", "span": "164", "frequency": "0.000", "frequency_skew": "0.002", "offset": "0.000000000", "stddev": "0.000000183"}, {"source_mode": "#", "source_state": "-", "source_name": "GPS", "stratum": "0", "polling_rate": "2", "reachability": "377", "lastrx": "2", "adjusted_offset": "0.016692873", "measured_offset": "0.016692873", "estimated_error": "0.002781948", "number_samplepoints": "6", "number_runs": "5", "span": "21", "frequency": "210.210", "frequency_skew": "964.386", "offset": "0.018130455", "stddev": "0.001614024"}]}
```