### PR TITLE
add DHCP stats to PiHole

### DIFF
--- a/snmp/pi-hole
+++ b/snmp/pi-hole
@@ -8,11 +8,17 @@ API_AUTH_KEY=""
 API_URL="localhost/admin/api.php"
 URL_READ_ONLY="?summaryRaw"
 URL_QUERY_TYPE="?getQueryTypes&auth="
+PICONFIGFILE='/etc/pihole/setupVars.conf'
+DHCPLEASEFILE='/etc/pihole/dhcp.leases'
 
 if [ -f $CONFIGFILE ]; then
     . $CONFIGFILE
 fi
 
+# read in pi-hole variables for DHCP range
+if [ -f $PICONFIGFILE ]; then
+    . $PICONFIGFILE
+fi
 
 #/ Description: BASH script to get Pi-hole stats
 #/ Examples: ./pi-hole-stats.sh
@@ -43,6 +49,12 @@ debug() {
 		echo '[ok] curl bin'
 	fi
 
+	if ! [ -x "$(command -v calc)" ]; then
+		echo '[error] calc binary not available, please install it'
+	else
+		echo '[ok] calc bin'
+	fi
+
 	if [ -z "$API_URL" ]; then
 		echo '[error] API_URL is not set'
 	else
@@ -66,6 +78,16 @@ debug() {
 	else
 		echo '[ok] URL_QUERY_TYPE not set'
 	fi
+	if [ -f $PICONFIGFILE ]; then
+		echo '[ok] Pi-Hole config file exists, DHCP stats will be captured if scope active'
+	else 
+		echo '[error] Pi-Hole config file does not exist, DHCP stats will not be captured if used'
+	fi
+	if [ -f $DHCPLEASEFILE ]; then
+		echo '[ok] DHCP lease file exists, DHCP stats will be captured if scope active'
+	else
+		echo '[error] DHCP lease file does not exist, DHCP stats will not be captured if used'
+	fi
 }
 
 exportdata() {
@@ -76,6 +98,23 @@ exportdata() {
 	# A / AAAA / PTR / SRV
 	GET_QUERY_TYPE=$(curl -s $API_URL$URL_QUERY_TYPE$API_AUTH_KEY | jq '.[]["A (IPv4)", "AAAA (IPv6)", "PTR", "SRV"]')
 	echo $GET_QUERY_TYPE | tr " " "\n"
+
+	# Find number of DHCP address in scope and current lease count
+	# case-insensitive compare, just in case :)
+	if [ "${DHCP_ACTIVE,,}" = "true" ]; then
+		# Max IP addresses in scope
+		# Convert IPs to decimal and subtract
+		IFS="." read -r -a array <<< $DHCP_START
+		DHCPSTARTDECIMAL=($(calc "(${array[0]}*256^3) + (${array[1]}*256^2) + (${array[2]}*256) + ${array[3]}"))
+		IFS="." read -r -a array <<< $DHCP_END
+		DHCPENDDECIMAL=($(calc "(${array[0]}*256^3) + (${array[1]}*256^2) + (${array[2]}*256) + ${array[3]}"))
+		expr $DHCPENDDECIMAL - $DHCPSTARTDECIMAL
+		# Current lease count
+		cat $DHCPLEASEFILE | wc -l
+	else
+		echo 0
+		echo 0
+	fi
 }
 
 if [ -z $* ]; then

--- a/snmp/pi-hole
+++ b/snmp/pi-hole
@@ -49,12 +49,6 @@ debug() {
 		echo '[ok] curl bin'
 	fi
 
-	if ! [ -x "$(command -v calc)" ]; then
-		echo '[error] calc binary not available, please install it'
-	else
-		echo '[ok] calc bin'
-	fi
-
 	if [ -z "$API_URL" ]; then
 		echo '[error] API_URL is not set'
 	else
@@ -105,9 +99,9 @@ exportdata() {
 		# Max IP addresses in scope
 		# Convert IPs to decimal and subtract
 		IFS="." read -r -a array <<< $DHCP_START
-		DHCPSTARTDECIMAL=($(calc "(${array[0]}*256^3) + (${array[1]}*256^2) + (${array[2]}*256) + ${array[3]}"))
+		DHCPSTARTDECIMAL=$(( (${array[0]}*256**3) + (${array[1]}*256**2) + (${array[2]}*256) + ${array[3]} ))
 		IFS="." read -r -a array <<< $DHCP_END
-		DHCPENDDECIMAL=($(calc "(${array[0]}*256^3) + (${array[1]}*256^2) + (${array[2]}*256) + ${array[3]}"))
+		DHCPENDDECIMAL=$(( (${array[0]}*256**3) + (${array[1]}*256**2) + (${array[2]}*256) + ${array[3]} ))
 		expr $DHCPENDDECIMAL - $DHCPSTARTDECIMAL
 		# Current lease count
 		cat $DHCPLEASEFILE | wc -l


### PR DESCRIPTION
Added code to export the maximum DHCP leases available, and the current number of DHCP leases.
If DHCP is not enabled in Pi-Hole "0" is returned for both values.

Note, extra config is required when implementing this - the path to the Pi-Hole variables, and the path to the DHCP leases file.
If this is a standard install of Pi-Hole, this should not need changing.

An added dependency of the `calc` command is required.
This can be installed by issuing a `apt-get install calc` on the pi.

This script was tested on PiHole v5

Changed PHP files are also required on the librenms server. This will be in a separate pull request.