### PR TITLE
gpsd python error

### DIFF
--- a/snmp/gpsd
+++ b/snmp/gpsd
@@ -26,7 +26,7 @@ TMPFILE=$(mktemp)
 trap "rm -f $TMPFILE" 0 2 3 15
 
 # Write GPSPIPE Data to Temp File
-$BIN_GPIPE -w -n 10 > $TMPFILE
+$BIN_GPIPE -w -n 20 > $TMPFILE
 
 # Parse Temp file for GPSD Data
 VERSION=`cat $TMPFILE | $BIN_GREP -m 1 "VERSION" | $BIN_PYTHON -c 'import sys,json;print json.load(sys.stdin)["rev"]'`


### PR DESCRIPTION
gpsd script occasionally results in python error.

cause: the expected sentence from GPS unit on each update has more than 10 lines, therefore, python didn't find the expected wording on some update and result in a python error
correction: increase the number of sentence to get from gpspipe from 10 to 20 lines