### PR TITLE
Update ups-apcups.sh

### DIFF
--- a/snmp/ups-apcups.sh
+++ b/snmp/ups-apcups.sh
@@ -19,7 +19,7 @@ BIN_GREP='/usr/bin/grep'
 ################################################################
 TMP=$($BIN_APCS 2>/dev/null)
 
-for value in "LINEV:[0-9]+" "LOADPCT:[0-9.]+" "BCHARGE:[0-9.]+" "TIMELEFT:[0-9.]+" "^BATTV:[0-9.]+" "NOMINV:[0-9]+" "NOMBATTV:[0-9.]+"
+for value in "^LINEV:[0-9]+" "LOADPCT:[0-9.]+" "BCHARGE:[0-9.]+" "TIMELEFT:[0-9.]+" "^BATTV:[0-9.]+" "NOMINV:[0-9]+" "NOMBATTV:[0-9.]+"
 do
         OUT=$(echo "$TMP" | $BIN_TR -d ' ' | $BIN_GREP -Eo "$value" | $BIN_CUT -d ":" -f 2)
         if [ -n "$OUT" ]; then


### PR DESCRIPTION
Filter out `LINEV` value as some APC models also return `MAXLINEV` and `MINLINEV` values in `apcaccess` output, therefore ruining the final output.