### PR TITLE
Change UPS name to be from arg value rather than hard coded

### DIFF
--- a/snmp/ups-nut.sh
+++ b/snmp/ups-nut.sh
@@ -9,7 +9,7 @@
 # 4. restart snmpd on the host                                 #
 # 5. activate the app for the desired host in LibreNMS         #
 ################################################################
-UPS_NAME='APCUPS'
+UPS_NAME="${1:-APCUPS}"
 
 PATH=$PATH:/usr/bin:/bin
 TMP=$(upsc $UPS_NAME 2>/dev/null)


### PR DESCRIPTION
Will still fallback to APCUPS

This change allows the UPS name to be specified in the configuration rather than fixed in code, and allows multiple UPS's be monitored without having multiple copies of the script
i.e.
```
extend ups-nut /etc/snmp/ups-nut.sh tripplite
extend ups-nut /etc/snmp/ups-nut.sh ups2
```