### PR TITLE
Tag VPP enabled distributions

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -147,4 +147,8 @@ elif [ "${OS}" = "FreeBSD" ] ; then
   fi
 fi
 
+if [ -f /etc/vpp/startup.conf ]; then
+  OSSTR="VPP ${OSSTR}"
+fi
+
 echo "${OSSTR}"


### PR DESCRIPTION
This is a companion change to https://github.com/librenms/librenms/pull/13230 which renders a VPP icon for these devices.

Using this icon, and tagging /usr/bin/distro with 'VPP' prepended to the ${OSSTR} we can accomplish rendering the VPP logo instead of the default Ubuntu/Debian logo.

Screenshot:
https://www.ipng.nl/tmp/librenms-vpp-icon-devicelist.png
https://www.ipng.nl/tmp/librenms-vpp-icon-detail.png

