### PR TITLE
fix occasionally random ordering for fail2ban

### DIFF
--- a/snmp/fail2ban
+++ b/snmp/fail2ban
@@ -157,7 +157,7 @@ sub stats{
 	}
 	
 	my $j=JSON->new;
-
+	$j->canonical(1);
 	if ( $_[0] ){
         $j->pretty(1);
 		return $j->encode( \%toReturn );


### PR DESCRIPTION
If

        $j->canonical(1);

need another changes, please fix that. 
I get this from: https://github.com/librenms/librenms-agent/pull/240