### PR TITLE
improve FreeRADIUS stats efficiency

### DIFF
--- a/snmp/freeradius.sh
+++ b/snmp/freeradius.sh
@@ -22,7 +22,7 @@ RADIUS_STATUS_CMD='Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 31
 BIN_GREP="$(command -v grep)"
 BIN_RADCLIENT="$(command -v radclient)"
 
-if [ $AGENT == 1 ]; then
+if [ $AGENT -eq 1 ]; then
   echo "<<<freeradius>>>"
 fi
 

--- a/snmp/freeradius.sh
+++ b/snmp/freeradius.sh
@@ -18,8 +18,8 @@ fi
 # Default radclient access request, shouldn't need to be changed
 RADIUS_STATUS_CMD='Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 31, Response-Packet-Type = Access-Accept'
 
-# Pathes for grep and radclient executables, should work if within PATH
-BIN_GREP="$(command -v grep)"
+# Paths for sed and radclient executables, should work if within PATH
+BIN_SED="$(command -v sed)"
 BIN_RADCLIENT="$(command -v radclient)"
 
 if [ $AGENT -eq 1 ]; then
@@ -28,44 +28,56 @@ fi
 
 RESULT=$(echo "$RADIUS_STATUS_CMD" | $BIN_RADCLIENT -x $RADIUS_SERVER:$RADIUS_PORT status $RADIUS_KEY)
 
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Access-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Access-Accepts = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Access-Rejects = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Access-Challenges = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Auth-Responses = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Auth-Duplicate-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Auth-Malformed-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Auth-Invalid-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Auth-Dropped-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Auth-Unknown-Types = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Accounting-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Accounting-Responses = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Acct-Duplicate-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Acct-Malformed-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Acct-Invalid-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Acct-Dropped-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Acct-Unknown-Types = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Access-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Access-Accepts = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Access-Rejects = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Access-Challenges = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Auth-Responses = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Auth-Duplicate-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Auth-Malformed-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Auth-Invalid-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Auth-Dropped-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Auth-Unknown-Types = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Accounting-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Accounting-Responses = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Acct-Duplicate-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Acct-Malformed-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Acct-Invalid-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Acct-Dropped-Requests = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Total-Proxy-Acct-Unknown-Types = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Queue-Len-Internal = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Queue-Len-Proxy = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Queue-Len-Auth = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Queue-Len-Acct = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Queue-Len-Detail = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Queue-PPS-In = [[:digit:]]*'
-echo "$RESULT" | $BIN_GREP -o 'FreeRADIUS-Queue-PPS-Out = [[:digit:]]*'
+if [[ $RESULT != *"Received Access-Accept"* ]] ;  then
+	# A valid result must contain the match string. Otherwise, verify:
+	# - the FreeRADIUS 'status' virtual server is enabled and running
+	# - the server, port or key match the 'status' server settings
+	echo "invalid result from radclient status request, check server settings"
+	exit 1
+fi
+
+# Return only those AV pairs expected by the FreeRADIUS app, one per line
+# Drop any leading or trailing whitespace
+# They may be returned in any order
+echo "$RESULT" | $BIN_SED -n \
+	-e 's/\s*\(FreeRADIUS-Total-Access-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Access-Accepts = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Access-Rejects = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Access-Challenges = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Auth-Responses = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Auth-Duplicate-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Auth-Malformed-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Auth-Invalid-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Auth-Dropped-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Auth-Unknown-Types = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Accounting-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Accounting-Responses = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Acct-Duplicate-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Acct-Malformed-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Acct-Invalid-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Acct-Dropped-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Acct-Unknown-Types = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Access-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Access-Accepts = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Access-Rejects = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Access-Challenges = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Auth-Responses = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Auth-Duplicate-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Auth-Malformed-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Auth-Invalid-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Auth-Dropped-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Auth-Unknown-Types = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Accounting-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Accounting-Responses = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Acct-Duplicate-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Acct-Malformed-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Acct-Invalid-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Acct-Dropped-Requests = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Total-Proxy-Acct-Unknown-Types = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Queue-Len-Internal = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Queue-Len-Proxy = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Queue-Len-Auth = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Queue-Len-Acct = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Queue-Len-Detail = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Queue-PPS-In = [0-9]*\)/\1/p' \
+	-e 's/\s*\(FreeRADIUS-Queue-PPS-Out = [0-9]*\)/\1/p'


### PR DESCRIPTION
Add some troubleshooting comments.
Change the AGENT variable comparison to numeric to avoid "unexpected operator" fault on bash 5 / Debian 11. 
Verify the radcheck result is valid before parsing it.
Parse result using a single call to sed with multiple commands to cut CPU time in half and syscalls by 90%.

Since the LibreNMS app module carefully extracts only the stats it needs, I experimented with just matching on FreeRADIUS-Total or FreeRADIUS-Queue, but found no significant improvement. At least this method explicitly declares what is being passed.

I canceled my prior similar PR which had dropped the .sh extension, since that could break existing configs.