### PR TITLE
Add rocky linux identification

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -35,6 +35,8 @@ elif [ "${OS}" = "Linux" ] ; then
       DIST="Oracle"
     elif [ -f /etc/rockstor-release ]; then
       DIST="Rockstor"
+    elif [ -f /etc/rocky-release ]; then
+      DIST="Rocky"
     else
       DIST="RedHat"
     fi


### PR DESCRIPTION
Added Rocky Linux identification. Also adding the svg file to the LibreNMS main repository.