### PR TITLE
Redesigned mdadm script to be more robust

### DIFF
--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -1,120 +1,64 @@
-#!/bin/bash
-
-CAT=/bin/cat
-LS=/bin/ls
-BASENAME=/usr/bin/basename
-REALPATH=/usr/bin/realpath
-
-CONFIGFILE=/etc/snmp/mdadm.conf
-if [ -f $CONFIGFILE ] ; then
-    # shellcheck disable=SC1090
-    . $CONFIGFILE
-fi
-
-VERSION=1
-ERROR_CODE=0
-ERROR_STRING=""
-
-OUTPUT_DATA='['
-
-# use 'ls' command to check if md blocks exist
-if $LS /dev/md?* 1> /dev/null 2>&1 ; then
-    for ARRAY_BLOCKDEVICE in $($LS -1 /dev/md?*) ; do
-        RAID="/sys/block/"$($BASENAME "$($REALPATH "$ARRAY_BLOCKDEVICE")")
-
-        # ignore arrays with no slaves
-        if [ -z "$($LS -1 "$RAID"/slaves 2> /dev/null)" ] ; then
-            continue
+#!/usr/bin/env bash
+# MDADM SNMP extension for LibreNMS
+# Outputs a list of devices
+list_devices() {
+    for device in "${1}/slaves/"*; do
+        if [ "${2,,}" == 'count' ]; then
+            ((devCount++))
+        elif [ "${2,,}" != 'missing' ] || [ ! -e "${device}" ]; then
+            printf "%b\t    \"$(basename "${device}")\"" "${multiDisk}"
+            multiDisk=',\n'
         fi
-        # ignore "non existing" arrays
-        if [ ! -f "$RAID/md/degraded" ] ; then
-            continue
-        fi
-
-        if [[ $($BASENAME "$ARRAY_BLOCKDEVICE") = [[:digit:]] ]] ; then
-            RAID_NAME=$($BASENAME "$RAID")
-        else
-            RAID_NAME=$($BASENAME "$ARRAY_BLOCKDEVICE")
-        fi
-        RAID_DEV_LIST=$($LS "$RAID"/slaves/)
-        RAID_LEVEL=$($CAT "$RAID"/md/level)
-        RAID_DISC_COUNT=$($CAT "$RAID"/md/raid_disks| cut -d' ' -f1)
-        RAID_STATE=$($CAT "$RAID"/md/array_state)
-        RAID_ACTION=$($CAT "$RAID"/md/sync_action)
-        RAID_DEGRADED=$($CAT "$RAID"/md/degraded)
-
-        if [ "$RAID_SYNC_SPEED" = "none" ] ; then
-            RAID_SYNC_SPEED=0
-        else
-            let "RAID_SYNC_SPEED=$($CAT "$RAID"/md/sync_speed)*1024"
-        fi
-
-        if [ "$($CAT "$RAID"/md/sync_completed)" != "none" ] ; then
-            let "RAID_SYNC_COMPLETED=100*$($CAT "$RAID"/md/sync_completed)"
-        elif [ "$RAID_DEGRADED" -eq 1 ] ; then
-            RAID_SYNC_COMPLETED=0
-        else
-            RAID_SYNC_COMPLETED=100
-        fi
-
-        # divide with 2 to size like in /proc/mdstat
-        # and multiply with 1024 to get size in bytes
-        let "RAID_SIZE=$($CAT "$RAID"/size)*1024/2"
-
-        RAID_DEVICE_LIST='['
-        ALL_DEVICE_COUNT=0
-        for D in $RAID_DEV_LIST ; do
-            RAID_DEVICE_LIST=$RAID_DEVICE_LIST'"'$D'",'
-            let "ALL_DEVICE_COUNT+=1"
-        done
-        if [ ${#RAID_DEVICE_LIST} -gt 3 ] ; then
-            RAID_DEVICE_LIST=${RAID_DEVICE_LIST: : -1}
-        fi
-        RAID_DEVICE_LIST=$RAID_DEVICE_LIST']'
-
-        RAID_MISSING_DEVICES='['
-        for D in $RAID_DEV_LIST ; do
-            if [ -L "$RAID"/slaves/"$D" ] && [ -f "$RAID"/slaves/"$D" ] ; then
-                RAID_MISSING_DEVICES=$RAID_MISSING_DEVICES'"'$D'",'
-            fi
-        done
-        if [ ${#RAID_MISSING_DEVICES} -gt 3 ] ; then
-            RAID_MISSING_DEVICES=${RAID_MISSING_DEVICES: : -1}
-        fi
-        RAID_MISSING_DEVICES=$RAID_MISSING_DEVICES']'
-
-        let "RAID_HOTSPARE_COUNT=ALL_DEVICE_COUNT-RAID_DISC_COUNT"
-        if [ "$RAID_HOTSPARE_COUNT" -lt 0 ] ; then
-            RAID_HOTSPARE_COUNT=0
-        fi
-
-        ARRAY_DATA='{'\
-'"name":"'$RAID_NAME\
-'","level":"'$RAID_LEVEL\
-'","size":"'$RAID_SIZE\
-'","disc_count":"'$RAID_DISC_COUNT\
-'","hotspare_count":"'$RAID_HOTSPARE_COUNT\
-'","device_list":'$RAID_DEVICE_LIST\
-',"missing_device_list":'$RAID_MISSING_DEVICES\
-',"state":"'$RAID_STATE\
-'","action":"'$RAID_ACTION\
-'","degraded":"'$RAID_DEGRADED\
-'","sync_speed":"'$RAID_SYNC_SPEED\
-'","sync_completed":"'$RAID_SYNC_COMPLETED\
-'"},'
-
-        OUTPUT_DATA=$OUTPUT_DATA$ARRAY_DATA
     done
+    [ "${devCount}" ] && echo "${devCount}"
+}
 
-    OUTPUT_DATA=${OUTPUT_DATA: : -1}']'
-else
-    OUTPUT_DATA=${OUTPUT_DATA}']'
-fi
+# Outputs either 0 or the value of the file referenced
+maybe_get() { if [ -f "${1}" ]; then cat "${1}"; else echo 0; fi }
 
-OUTPUT='{"data":'$OUTPUT_DATA\
-',"error":"'$ERROR_CODE\
-'","errorString":"'$ERROR_STRING\
-'","version":"'$VERSION'"}'
+mdadmSNMPOutput='{ "data": ['
+for mdadmArray in /dev/md*; do
+    # Ignore mdadm folders
+    [ -d "${mdadmArray}" ] && continue
 
-echo "$OUTPUT"
+    mdadmName="$(basename "$(realpath "${mdadmArray}")")"
+    mdadmSysDev="/sys/block/${mdadmName}"
 
+    read -r -d '' mdadmOutput <<MDADMJSON
+    ${multiArray}{
+        "name": "${mdadmName}",
+        "level": "$(cat "${mdadmSysDev}/md/level")",
+        "size": "$((($(cat "${mdadmSysDev}/size") * 1024) / 2))",
+        "disc_count": "$(cat "${mdadmSysDev}/md/raid_disks")",
+        "hotspare_count": "$((($(list_devices "${mdadmSysDev}" count "${mdadmSysDev}") - $(cat "${mdadmSysDev}/md/raid_disks"))))",
+        "device_list": [
+$(list_devices "${mdadmSysDev}")
+        ],
+        "missing_devices_list": [
+$(list_devices "${mdadmSysDev}" missing)
+        ],
+        "state": "$(cat "${mdadmSysDev}/md/array_state")",
+        "action": "$(maybe_get "${mdadmSysDev}/md/sync_action")",
+        "degraded": "$(maybe_get "${mdadmSysDev}/md/degraded")",
+        "sync_speed": "$(($(maybe_get "${mdadmSysDev}/md/sync_speed") * 1024))",
+        "sync_completed": "$(maybe_get "${mdadmSysDev}/md/sync_completed")"
+    }
+MDADMJSON
+    # Add a comma only after the first item
+    multiArray=','
+
+    mdadmSNMPOutput+="${mdadmOutput}"
+done
+
+    read -r -d '' metadataOutput <<METADATA
+],
+    "error": "0",
+    "errorString": "",
+    "version": "1"
+}
+METADATA
+
+echo "${mdadmSNMPOutput//$'\n'/}${metadataOutput//$'\n'/}" | sed 's/\s//g'
+
+# Very basic debug flag
+[ "${1,,}" == '--debug' ] && echo "${mdadmSNMPOutput}${metadataOutput}"

--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -17,9 +17,9 @@ list_devices() {
 maybe_get() { if [ -f "${1}" ]; then cat "${1}"; else echo 0; fi }
 
 mdadmSNMPOutput='{ "data": ['
-for mdadmArray in /dev/md*; do
-    # Ignore mdadm folders
-    [ -d "${mdadmArray}" ] && continue
+for mdadmArray in "/dev/md"[[:digit:]]*; do
+    # Ignore partitions
+    if [[ "${mdadmArray}" =~ '/dev/md'[[:digit:]]+'p' ]]; then continue; fi
 
     mdadmName="$(basename "$(realpath "${mdadmArray}")")"
     mdadmSysDev="/sys/block/${mdadmName}"


### PR DESCRIPTION
This updates the mdadm SNMP script to be cleaner and more robust (it was failing prior with specific RAID configurations). Here is a random set of assorted RAID 0s:
```
[root@stor01a-rh8 ~]# /etc/snmp/mdadm 
{"data":[{"name":"md124","level":"raid0","size":"18003119308800","disc_count":"3","hotspare_count":"0","device_list":["sdc","sdd","sde"],"missing_devices_list":[],"state":"clean","action":"0","degraded":"0","sync_speed":"0","sync_completed":"0"},{"name":"md125","level":"raid0","size":"12002079539200","disc_count":"2","hotspare_count":"0","device_list":["sda","sdb"],"missing_devices_list":[],"state":"clean","action":"0","degraded":"0","sync_speed":"0","sync_completed":"0"},{"name":"md126","level":"raid0","size":"1860725374976","disc_count":"2","hotspare_count":"0","device_list":["nvme0n1p4","nvme1n1p2"],"missing_devices_list":[],"state":"clean","action":"0","degraded":"0","sync_speed":"0","sync_completed":"0"},{"name":"md127","level":"raid0","size":"137571074048","disc_count":"2","hotspare_count":"0","device_list":["nvme0n1p3","nvme1n1p1"],"missing_devices_list":[],"state":"clean","action":"0","degraded":"0","sync_speed":"0","sync_completed":"0"}],"error":"0","errorString":"","version":"1"}
```
And a separate RAID 1 (and with `--debug`):
```
[root@kvm01-rh8 ~]# /etc/snmp/mdadm  --debug
{"data":[{"name":"md127","level":"raid1","size":"2000398778368","disc_count":"2","hotspare_count":"0","device_list":["nvme0n1","nvme1n1"],"missing_devices_list":[],"state":"clean","action":"idle","degraded":"0","sync_speed":"0","sync_completed":"none"}],"error":"0","errorString":"","version":"1"}
{ "data": [{
        "name": "md127",
        "level": "raid1",
        "size": "2000398778368",
        "disc_count": "2",
        "hotspare_count": "0",
        "device_list": [
            "nvme0n1",
            "nvme1n1"
        ],
        "missing_devices_list": [

        ],
        "state": "clean",
        "action": "idle",
        "degraded": "0",
        "sync_speed": "0",
        "sync_completed": "none"
    }],
    "error": "0",
    "errorString": "",
    "version": "1"
}
```