### PR TITLE
Provide dhcpd-pools leasefile location

### DIFF
--- a/snmp/dhcp.py
+++ b/snmp/dhcp.py
@@ -65,7 +65,7 @@ if not error:
                     elif "binding state free" in line:
                         leases["free"] += 1
 
-shell_cmd = "dhcpd-pools -s i -A"
+shell_cmd = "dhcpd-pools -s i -A -l" + configfile["leasefile"]
 pool_data = (
     subprocess.Popen(shell_cmd, shell=True, stdout=subprocess.PIPE)
     .stdout.read()


### PR DESCRIPTION
pfSense 2.6 would previously throw an error when executing the dhcp.py script:
```dhcpd-pools: parse_leases: /var/db/dhcpd/dhcpd.leases: No such file or directory```

Passing the configured leasefile location to dhcpd-pools fixes this issue.