### PR TITLE
mdadm sync check - completed percent

### DIFF
--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -20,7 +20,9 @@ list_devices() {
 
 # Outputs either 0, 100, or the value of the file referenced
 maybe_get() {
-    if [ -f "${1}" ] && [ "$(cat "${1}")" != 'none' ]; then
+    if [[ $(cat "${1}") =~ " / " ]]; then
+        echo "100 * $(cat ${1})" | bc
+    elif [ -f "${1}" ] && [ "$(cat "${1}")" != 'none' ]; then
         cat "${1}"
     else
         echo 0


### PR DESCRIPTION
On my system mdadm runs periodic checks and while running the smtp agent will not work. This PR handles this case. These are my values:

# cat /proc/mdstat
Personalities : [raid1] [raid6] [raid5] [raid4]
md127 : active raid6 sdm1[8] sdj1[7] sdh1[6] sdf1[4] sdd1[2] sdg1[5] sdl1[9] sde1[3] sdb1[0] sdc1[1]
      31255019520 blocks super 1.2 level 6, 128k chunk, algorithm 2 [10/10] [UUUUUUUUUU]
      [========>............]  check = 40.4% (1579717248/3906877440) finish=2589.7min speed=14976K/sec
      bitmap: 1/30 pages [4KB], 65536KB chunk

# cat /sys/block/md127/md/sync_completed
3159583488 / 7813754880
