### PR TITLE
Fix mdadm cat Errors

### DIFF
--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -20,8 +20,8 @@ list_devices() {
 
 # Outputs either 0, 100, or the value of the file referenced
 maybe_get() {
-    if [[ $(cat "${1}") =~ " / " ]]; then
-        echo "100 * $(cat ${1})" | bc
+    if [ -f "${1}" ] && [[ $(cat "${1}") =~ " / " ]]; then
+        echo $((100 * $(cat "${1}")))
     elif [ -f "${1}" ] && [ "$(cat "${1}")" != 'none' ]; then
         cat "${1}"
     else


### PR DESCRIPTION
This fixes the following errors, which are a result of an attempt to `cat` a file when it does not exist due to #415 :
```
cat: /sys/block/md124/md/degraded: No such file or directory
cat: /sys/block/md124/md/sync_speed: No such file or directory
cat: /sys/block/md124/md/sync_completed: No such file or directory
cat: /sys/block/md124/md/sync_action: No such file or directory
cat: /sys/block/md125/md/degraded: No such file or directory
cat: /sys/block/md125/md/sync_speed: No such file or directory
cat: /sys/block/md125/md/sync_completed: No such file or directory
cat: /sys/block/md125/md/sync_action: No such file or directory
cat: /sys/block/md126/md/degraded: No such file or directory
cat: /sys/block/md126/md/sync_speed: No such file or directory
cat: /sys/block/md126/md/sync_completed: No such file or directory
cat: /sys/block/md126/md/sync_action: No such file or directory
cat: /sys/block/md127/md/degraded: No such file or directory
cat: /sys/block/md127/md/sync_speed: No such file or directory
cat: /sys/block/md127/md/sync_completed: No such file or directory
cat: /sys/block/md127/md/sync_action: No such file or directory
{"data":[{"name":"md124","level":"raid0","size":12002079539200,"disc_count":2,"hotspare_count":0,"device_list":["sdc","sde"],"missing_devices_list":[],"state":"clean","action":"0","degraded":0,"sync_speed":0,"sync_completed":100},{"name":"md125","level":"raid0","size":18003119308800,"disc_count":3,"hotspare_count":0,"device_list":["sda","sdb","sdd"],"missing_devices_list":[],"state":"clean","action":"0","degraded":0,"sync_speed":0,"sync_completed":100},{"name":"md126","level":"raid0","size":1860725374976,"disc_count":2,"hotspare_count":0,"device_list":["nvme0n1p4","nvme1n1p2"],"missing_devices_list":[],"state":"clean","action":"0","degraded":0,"sync_speed":0,"sync_completed":100},{"name":"md127","level":"raid0","size":137571074048,"disc_count":2,"hotspare_count":0,"device_list":["nvme0n1p3","nvme1n1p1"],"missing_devices_list":[],"state":"clean","action":"0","degraded":0,"sync_speed":0,"sync_completed":100}],"error":0,"errorString":"","version":"2.0.0"}
```

This also removes the reliance on `bc` by using bash's built in math capabilities.
@oernii if you can test this and make sure it works on your setup that would be great.