### PR TITLE
run_query PHP 8.1 fix

### DIFF
--- a/snmp/mysql
+++ b/snmp/mysql
@@ -1310,6 +1310,7 @@ function to_int ( $str ) {
 function run_query($sql, $conn) {
    global $debug;
    debug($sql);
+   mysqli_report(MYSQLI_REPORT_OFF);
    $result = @mysqli_query($conn, $sql);
    if ( $debug && strpos($sql, 'SHOW SLAVE STATUS ') === false ) {
       $error = @mysqli_error($conn);
@@ -1319,13 +1320,15 @@ function run_query($sql, $conn) {
       }
    }
    $array = array();
-   $count = @mysqli_num_rows($result);
-   if ( $count > 10000 ) {
-      debug('Abnormal number of rows returned: ' . $count);
-   }
-   else {
-      while ( $row = @mysqli_fetch_array($result) ) {
-         $array[] = $row;
+   if ( $result ) {
+      $count = @mysqli_num_rows($result);
+      if ( $count > 10000 ) {
+         debug('Abnormal number of rows returned: ' . $count);
+      }
+      else {
+         while ( $row = @mysqli_fetch_array($result) ) {
+	    $array[] = $row;
+         }
       }
    }
    debug(array($sql, $array));


### PR DESCRIPTION
https://www.php.net/manual/en/mysqli-driver.report-mode.php
As of PHP 8.1.0, the default setting is MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT. Previously, it was MYSQLI_REPORT_OFF.

Before the fix on PHP 8.1 and MariaDB 10.6.7 the script will fail with an error like this:

```
PHP Fatal error:  Uncaught mysqli_sql_exception: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'NONBLOCKING' at line 1 in /etc/snmp/mysql:1313
Stack trace:
#0 /etc/snmp/mysql(1313): mysqli_query()
#1 /etc/snmp/mysql(422): run_query()
#2 /etc/snmp/mysql(141): ss_get_mysql_stats()
#3 {main}
  thrown in /etc/snmp/mysql on line 1313
```