### PR TITLE
Fixing agent-local hddtemp script

### DIFF
--- a/agent-local/hddtemp
+++ b/agent-local/hddtemp
@@ -28,9 +28,9 @@ if [ "${hddtemp}" != "" ]; then
 	if [ -x "${hddtemp}" ]; then
 		if type parallel > /dev/null 2>&1; then
 			# When available, use GNU parallel for a significant performance boost. hddtemp runs serially(!)
-			output=$(parallel "${hddtemp}" -w -q ::: "${disks}" 2>/dev/null)
+			output=$(parallel "${hddtemp}" -w -q ::: ${disks} 2>/dev/null)
 		else
-			output=$(${hddtemp} -w -q "${disks}" 2>/dev/null)
+			output=$(${hddtemp} -w -q ${disks} 2>/dev/null)
 		fi
 		content=$(echo "$output" | awk '{ if ($0 !~ /not available/) { print $0 } }' | awk -F": " 'BEGIN{ ORS="" }{ print "|"$1"|"$2"|"$3"|";} ' | sed 's/[° ]C|/|C|/g' | sed 's/[° ]F|/|F|/g' | tr -cd '\12\14\40-\176')
 		if [ "${content}" != "" ]; then


### PR DESCRIPTION
With quotes surrounding ${disks}, the hddtemp command attempts to execute across the entire string.  If, for instance, the string contains multiple drives like "/dev/sda /dev/sdb", then this entire string is what hddtemp operates over.  Without quotes, however, hddtemp parses each space-delimited drive individually:

With quotes (bad):
```
[abc@xyz ~]$ echo $disks
/dev/sda /dev/sda1
[abc@xyz ~]$ echo $hddtemp
/usr/bin/hddtemp
[abc@xyz ~]$ ${hddtemp} -w -q "${disks}"
/dev/sda /dev/sda1: open: No such file or directory
[abc@xyz ~]$ sudo /usr/lib/check_mk_agent/local/hddtemp
<<<hddtemp>>>
||||

[abc@xyz ~]$ 
```

Without quotes (good):
```
[abc@xyz ~]$ echo $disks
/dev/sda /dev/sda1
[abc@xyz ~]$ echo $hddtemp
/usr/bin/hddtemp
[abc@xyz ~]$ ${hddtemp} -w -q ${disks}
/dev/sda: Samsung SSD 850 EVO 250GB: 34°C
/dev/sda1: Samsung SSD 850 EVO 250GB: 34°C
[abc@xyz ~]$ sudo /usr/lib/check_mk_agent/local/hddtemp
<<<hddtemp>>>
|/dev/sda|Samsung SSD 850 EVO 250GB|34|C||/dev/sda1|Samsung SSD 850 EVO 250GB|34|C|

[abc@xyz ~]$
```