### PR TITLE
Adding optional configuration file support to postgres snmp script

### DIFF
--- a/snmp/postgres
+++ b/snmp/postgres
@@ -22,19 +22,53 @@
 #OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 #THE POSSIBILITY OF SUCH DAMAGE.
 
-#set the user here to use
-#be sure to set up the user in .pgpass for the user snmpd is running as
+# Location of optional config file.
+CONFIG_FILE="/etc/snmp/postgres.config"
+
+# Default DBuser is pgsql.  Be sure to set up the user in .pgpass for the user snmpd
+# is running as.  You can either update the variable below, or add "DBuser=<username>"
+# to the /etc/snmp/postgres.config file without quotes and replacing <username>.
 DBuser=pgsql
 
 # You may want to disable totalling for the postgres DB as that can make the total graphs artificially noisy.
 # 1 = don't total stats for the DB postgres
 # 0 = include postgres in the totals
+# To set this to 0, you can either update the variable below, or add "ignorePG=0" to
+# the /etc/snmp/postgres.config file (without quotes).
 ignorePG=1;
+
+# Hostname to connect to.  By default this is blank and check_postgres.ph will connect
+# to the Unix socket.  You can either update the variable below, or add "DBhost=<hostname>"
+# to the  /etc/snmp/postgres.config file without quotes and replacing <hostname>.
+DBhost=""
+
+# Load configuration from config file if the file exists.
+if [ -f "$CONFIG_FILE" ]; then
+    saved_IFS=$IFS
+    IFS="="
+
+    while read -r key value; do
+        if [ "$key" = "DBuser" ]; then
+            DBuser=$value
+        elif [ "$key" = "ignorePG" ]; then
+            ignorePG=$value
+        elif [ "$key" = "DBhost" ]; then
+            DBhost=$value
+        fi
+    done < $CONFIG_FILE
+
+    IFS=$saved_IFS
+fi
 
 #make sure the paths are right for your system
 cpg='/usr/bin/env check_postgres.pl'
 
-$cpg -u $DBuser --action dbstats | awk -F ' ' '
+cpg_command="$cpg -u $DBuser --action dbstats"
+if [ "$DBhost" != "" ]; then
+    cpg_command="$cpg_command -H $DBhost"
+fi
+
+$cpg_command | awk -F ' ' '
 
 BEGIN{
 	backends=0;


### PR DESCRIPTION
I've added configuration file support so that users can more easily update the postgres script on their local systems without worrying about whether doing so will overwrite any custom settings (such as the DBuser).  The configuration file is completely optional for backwards-compatibility.

I've also added the ability to specify the hostname for check_postgres.pl to connect to, since connecting to the Unix socket in my case results in authentication failures (the .pgpass file is completely ignored).  Specifying the hostname as "localhost" rectifies this issue.  The default of connecting to the Unix socket is not changed, however.

Documentation update PR submitted here: https://github.com/librenms/librenms/pull/14627