### PR TITLE
snmp/Openwrt/wl*: Added stderr redirects in wl* scripts for iw/iwlist.

### DIFF
--- a/snmp/Openwrt/wlClients.sh
+++ b/snmp/Openwrt/wlClients.sh
@@ -25,7 +25,7 @@ fi
 count=0
 for interface in $interfaces
 do
-	new=$(/usr/sbin/iw dev "$interface" station dump | /bin/grep Station | /usr/bin/cut -f 2 -s -d" " | /usr/bin/wc -l)
+	new=$(/usr/sbin/iw dev "$interface" station dump 2>/dev/null | /bin/grep Station | /usr/bin/cut -f 2 -s -d" " | /usr/bin/wc -l)
   	count=$(( $count + $new ))
 done
 

--- a/snmp/Openwrt/wlFrequency.sh
+++ b/snmp/Openwrt/wlFrequency.sh
@@ -12,7 +12,7 @@ if [ $# -ne 1 ]; then
 fi
 
 # Extract frequency
-frequency=$(/usr/sbin/iw dev "$1" info | /bin/grep channel | /usr/bin/cut -f 2- -s -d" " | /usr/bin/cut -f 2- -s -d"(" | /usr/bin/cut -f 1 -s -d" ")
+frequency=$(/usr/sbin/iw dev "$1" info 2>/dev/null | /bin/grep channel | /usr/bin/cut -f 2- -s -d" " | /usr/bin/cut -f 2- -s -d"(" | /usr/bin/cut -f 1 -s -d" ")
 
 # Return snmp result
 /bin/echo "$frequency"

--- a/snmp/Openwrt/wlNoiseFloor.sh
+++ b/snmp/Openwrt/wlNoiseFloor.sh
@@ -13,7 +13,7 @@ fi
 
 # Extract noise floor. Note, all associated stations have the same value, so just grab the first one
 # Use tail, not head (i.e. last line, not first), as head exits immediately, breaks the pipe to cut!
-noise=$(/usr/bin/iwinfo "$1" assoclist | /usr/bin/cut -s -d "/" -f 2 | /usr/bin/cut -s -d "(" -f 1 | /usr/bin/cut -s -d " " -f 2 | /usr/bin/tail -1)
+noise=$(/usr/bin/iwinfo "$1" assoclist 2>/dev/null | /usr/bin/cut -s -d "/" -f 2 | /usr/bin/cut -s -d "(" -f 1 | /usr/bin/cut -s -d " " -f 2 | /usr/bin/tail -1)
 
 # Return snmp result
 /bin/echo "$noise"

--- a/snmp/Openwrt/wlRate.sh
+++ b/snmp/Openwrt/wlRate.sh
@@ -16,7 +16,8 @@ fi
 
 # Calculate result. Sum just for debug, and have to return integer
 # => If not integer (e.g. 2.67e+07), LibreNMS will drop the exponent (result, 2.67 bits/sec!)
-ratelist=$(/usr/sbin/iw dev "$1" station dump | /bin/grep "$2 bitrate" | /usr/bin/cut -f 2 -s -d" ")
+ratelist=$(/usr/sbin/iw dev "$1" station dump 2>/dev/null | /bin/grep "$2 bitrate" | /usr/bin/cut -f 2 -s -d" ")
+result=0
 if [ "$3" = "sum" ]; then
   result=$(/bin/echo "$ratelist" | /usr/bin/awk -F ':' '{sum += $2} END {printf "%d\n", 1000000*sum}')
 elif [ "$3" = "avg" ]; then

--- a/snmp/Openwrt/wlSNR.sh
+++ b/snmp/Openwrt/wlSNR.sh
@@ -14,7 +14,7 @@ if [ $# -ne 2 ]; then
 fi
 
 # Calculate result. Sum just for debug, and return integer (safest / easiest)
-snrlist=$(/usr/bin/iwinfo "$1" assoclist | /usr/bin/cut -s -d "/" -f 2 | /usr/bin/cut -s -d "(" -f 2 | /usr/bin/cut -s -d " " -f 2 | /usr/bin/cut -s -d ")" -f 1)
+snrlist=$(/usr/bin/iwinfo "$1" assoclist 2>/dev/null | /usr/bin/cut -s -d "/" -f 2 | /usr/bin/cut -s -d "(" -f 2 | /usr/bin/cut -s -d " " -f 2 | /usr/bin/cut -s -d ")" -f 1)
 if [ "$2" = "sum" ]; then
   result=$(/bin/echo "$snrlist" | /usr/bin/awk -F ':' '{sum += $1} END {printf "%d\n", sum}')
 elif [ "$2" = "avg" ]; then


### PR DESCRIPTION
See Issue mentioned in librenms/librenms:
#14428 OpenWRT example scripts give bad output if wireless interface is down.

Redirect the iw/iwlist command stderr output to /dev/null.