### PR TITLE
Address script failure with parameters

### DIFF
--- a/snmp/wireguard.py
+++ b/snmp/wireguard.py
@@ -234,11 +234,12 @@ def main():
         # Parse each line and import the resultant dictionary into output_data.  We update the
         # interface key with new clients as they are found and instantiate new interface keys as
         # they are found.
-        for intf, intf_data in output_parser(line, interface_clients_dict).items():
-            if intf not in output_data["data"]:
-                output_data["data"][intf] = {}
-            for client, client_data in intf_data.items():
-                output_data["data"][intf][client] = client_data
+        if len(line.strip().split()) == 9:
+            for intf, intf_data in output_parser(line, interface_clients_dict).items():
+                if intf not in output_data["data"]:
+                    output_data["data"][intf] = {}
+                for client, client_data in intf_data.items():
+                    output_data["data"][intf][client] = client_data
 
     print(json.dumps(output_data))
 


### PR DESCRIPTION
The current script fails to run if any parameters are set for the interface, like (for example), FwMark ... the reason is,

wg show all dump

outputs this info as well, which doesn't work with the current logic.