### PR TITLE
Latest pi-hole API needs auth parameter for summary

### DIFF
--- a/snmp/pi-hole
+++ b/snmp/pi-hole
@@ -6,20 +6,20 @@ CONFIGFILE='/etc/snmp/pi-hole.conf'
 
 API_AUTH_KEY=""
 API_URL="localhost/admin/api.php"
-URL_READ_ONLY="?summaryRaw"
+URL_READ_ONLY="?summaryRaw&auth="
 URL_QUERY_TYPE="?getQueryTypes&auth="
 PICONFIGFILE='/etc/pihole/setupVars.conf'
 DHCPLEASEFILE='/etc/pihole/dhcp.leases'
 
 if [ -f $CONFIGFILE ]; then
-    # shellcheck disable=SC1090
-    . $CONFIGFILE
+	# shellcheck disable=SC1090
+	. $CONFIGFILE
 fi
 
 # read in pi-hole variables for DHCP range
 if [ -f $PICONFIGFILE ]; then
-    # shellcheck disable=SC1090
-    . $PICONFIGFILE
+	# shellcheck disable=SC1090
+	. $PICONFIGFILE
 fi
 
 #/ Description: BASH script to get Pi-hole stats
@@ -89,24 +89,24 @@ debug() {
 exportdata() {
 	# domains_being_blocked / dns_query_total / ads_blocked_today / ads_percentage_today
 	# unique_domains / queries_forwarded / queries_cached
-	GET_STATS=$(curl -s $API_URL"$URL_READ_ONLY" | jq '.domains_being_blocked, .dns_queries_today, .ads_blocked_today, .ads_percentage_today, .unique_domains, .queries_forwarded, .queries_cached')
+	GET_STATS=$(curl -s "${API_URL}${URL_READ_ONLY}${API_AUTH_KEY}" | jq '.domains_being_blocked, .dns_queries_today, .ads_blocked_today, .ads_percentage_today, .unique_domains, .queries_forwarded, .queries_cached')
 	echo "$GET_STATS" | tr " " "\n"
 	# A / AAAA / PTR / SRV
-	GET_QUERY_TYPE=$(curl -s $API_URL"$URL_QUERY_TYPE""$API_AUTH_KEY" | jq '.[]["A (IPv4)", "AAAA (IPv6)", "PTR", "SRV"]')
+	GET_QUERY_TYPE=$(curl -s "${API_URL}${URL_QUERY_TYPE}${API_AUTH_KEY}" | jq '.[]["A (IPv4)", "AAAA (IPv6)", "PTR", "SRV"]')
 	echo "$GET_QUERY_TYPE" | tr " " "\n"
 
 	# Find number of DHCP address in scope and current lease count
 	# case-insensitive compare, just in case :)
-	if [ "${DHCP_ACTIVE,,}" = "true" ]; then
+	if [ -n "${DHCP_ACTIVE+x}" ] && [ "${DHCP_ACTIVE,,}" = "true" ]; then
 		# Max IP addresses in scope
 		# Convert IPs to decimal and subtract
 		IFS="." read -r -a array <<< "$DHCP_START"
-		DHCPSTARTDECIMAL=$(( (${array[0]}*256**3) + (${array[1]}*256**2) + (${array[2]}*256) + ${array[3]} ))
+		DHCPSTARTDECIMAL=$(( (array[0]*256**3) + (array[1]*256**2) + (array[2]*256) + array[3] ))
 		IFS="." read -r -a array <<< "$DHCP_END"
-		DHCPENDDECIMAL=$(( (${array[0]}*256**3) + (${array[1]}*256**2) + (${array[2]}*256) + ${array[3]} ))
-		expr $DHCPENDDECIMAL - $DHCPSTARTDECIMAL
+		DHCPENDDECIMAL=$(( (array[0]*256**3) + (array[1]*256**2) + (array[2]*256) + array[3] ))
+		echo $(( DHCPENDDECIMAL - DHCPSTARTDECIMAL ))
 		# Current lease count
-		cat $DHCPLEASEFILE | wc -l
+		wc -l < ${DHCPLEASEFILE}
 	else
 		echo 0
 		echo 0
@@ -114,7 +114,7 @@ exportdata() {
 }
 
 if [ -z "$*" ]; then
-        exportdata
+	exportdata
 fi
 expr "$*" : ".*--help" > /dev/null && usage
 expr "$*" : ".*--debug" > /dev/null && debug


### PR DESCRIPTION
The latest [pi-hole update](https://pi-hole.net/blog/2022/11/17/upcoming-changes-authentication-for-more-api-endpoints-required/#page-content) requires the `auth` parameter also for the normal summary. Former versions just ignore it which makes this change backward compatible.

I also included a fix #366 to check if `DHCP_ACTIVE` is set and changed a few things according to "shellcheck" feedback.