### PR TITLE
Removing unnecessary backslashes and whitespace from postgres script.

### DIFF
--- a/snmp/postgres
+++ b/snmp/postgres
@@ -12,11 +12,11 @@
 #    and/or other materials provided with the distribution.
 #
 #THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-#ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+#ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 #WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
 #IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-#INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-#BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+#INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 #DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 #LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 #OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
@@ -91,27 +91,27 @@ BEGIN{
 	db="";
     ignorePG='$ignorePG';
 	toAdd=1;
-}  
+}
 {
-	gsub(/dbname\:/, "");
-	gsub(/backends\:/, ""); 
-	gsub(/commits\:/, ""); 
-	gsub(/rollbacks\:/, ""); 
-	gsub(/idxscan\:/, ""); 
-	gsub(/idxtupread\:/, ""); 
-	gsub(/idxtupfetch\:/, ""); 
-	gsub(/idxblksread\:/, ""); 
-	gsub(/idxblkshit\:/, ""); 
-	gsub(/seqscan\:/, ""); 
-	gsub(/seqtupread\:/, ""); 
-	gsub(/ret\:/, "");
-	gsub(/fetch\:/, "");
-	gsub(/ins\:/, "");
-	gsub(/upd\:/, "");
-	gsub(/del\:/, ""); 
+	gsub(/dbname:/, "");
+	gsub(/backends:/, "");
+	gsub(/commits:/, "");
+	gsub(/rollbacks:/, "");
+	gsub(/idxscan:/, "");
+	gsub(/idxtupread:/, "");
+	gsub(/idxtupfetch:/, "");
+	gsub(/idxblksread:/, "");
+	gsub(/idxblkshit:/, "");
+	gsub(/seqscan:/, "");
+	gsub(/seqtupread:/, "");
+	gsub(/ret:/, "");
+	gsub(/fetch:/, "");
+	gsub(/ins:/, "");
+	gsub(/upd:/, "");
+	gsub(/del:/, "");
 	#must be processed last or they step on other gsub
-	gsub(/read\:/, "");
-	gsub(/hit\:/, "");
+	gsub(/read:/, "");
+	gsub(/hit:/, "");
 
 	if ( $18 == "postgres" ){
 	  if ( ignorePG == 1 ){ toAdd=0 }


### PR DESCRIPTION
In EL9 (Rocky Linux 9 in my case), awk complains that "escaping" semi-colons is not a known regexp operator:

```
# /etc/snmp/postgres
awk: cmd. line:26: warning: regexp escape sequence `\:' is not a known regexp operator
3
37521
15
5998
1323852
0
0
0
0
0
0
0
9295351
489767
34754
2269
211
0 428 3 179 104443 0 0 0 0 0 0 0 29014 24545 338 28 4
1 3535 3 1073 157557 0 0 0 0 0 0 0 1536174 43846 0 0 0 postgres
0 4304 1 2052 222546 0 0 0 0 0 0 0 1573088 55475 17569 743 34 template1
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 template0
3 32789 11 3767 996863 0 0 0 0 0 0 0 7693249 409747 16847 1498 173 netbox
```

It looks like the backslashes are unnecessary.  After the change, the script no longer complains:
```
# /etc/snmp/postgres
3
37601
15
5998
1330116
0
0
0
0
0
0
0
9382530
490758
34754
2269
211
0 428 3 179 106207 0 0 0 0 0 0 0 29493 24976 338 28 4
1 3621 3 1073 173704 0 0 0 0 0 0 0 1605431 51504 0 0 0 postgres
0 4344 1 2052 224006 0 0 0 0 0 0 0 1590588 55755 17569 743 34 template1
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 template0
3 32829 11 3767 999903 0 0 0 0 0 0 0 7762449 410027 16847 1498 173 netbox
```

I also tested this change on an older CentOS Stream 8 deployment (that was not throwing the same warning) and there were no issues after the fact:

```
# /etc/snmp/postgres
57
226746033
1169125
2938614572
30383070964
0
0
0
0
0
0
0
213708212890
9290174356
224143471
101152759
213187818
0 0 0 1415 122590724 0 0 0 0 0 0 0 37528261 29315576 20 7 13
1 914742 28 176405 99787755 0 0 0 0 0 0 0 676516979 36226513 0 0 0 postgres
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 template1
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 template0
37 118447673 45841 425637817 12104052618 0 0 0 0 0 0 0 45371192282 6574031992 215915150 51235688 206451273 foreman
9 6194682 1115664 1236636 525640369 0 0 0 0 0 0 0 1772092120 222075755 268103 74456 266495 candlepin
11 102103678 7620 2511738704 17630787253 0 0 0 0 0 0 0 166527400227 2464751033 7960198 49842608 6470037 pulpcore
```