### PR TITLE
Smart: fetch the values 177, 231 and 233 as normalized instead of raw

### DIFF
--- a/snmp/smart
+++ b/snmp/smart
@@ -326,6 +326,7 @@ foreach my $line ( @disks ){
 			if ( $line =~ /^[0123456789]+ / ) {
 				my @lineA=split(/\ /, $line, 10);
 				my $raw=$lineA[9];
+				my $normalized=$lineA[3];
 				my $id=$lineA[0];
 
 				# Crucial SSD
@@ -339,19 +340,25 @@ foreach my $line ( @disks ){
 					( $id == 5 ) ||
 					( $id == 10 ) ||
 					( $id == 173 ) ||
-					( $id == 177 ) ||
 					( $id == 183 ) ||
 					( $id == 184 ) ||
 					( $id == 187 ) ||
 					( $id == 196 ) ||
 					( $id == 197 ) ||
 					( $id == 198 ) ||
-					( $id == 199 ) ||
-					( $id == 231 ) ||
-					( $id == 233 )
+					( $id == 199 )
 					) {
 					my @rawA=split( /\ /, $raw );
 					$IDs{$id}=$rawA[0];
+				}
+
+				# single int normalized values
+				if (
+					( $id == 177 ) ||
+					( $id == 231 ) ||
+					( $id == 233 )
+					) {
+					$IDs{$id}=int($normalized);
 				}
 
 				# 9, power on hours


### PR DESCRIPTION
Dear LibreNMS developers,

After investigating how SMART can be monitored efficiently, I discovered that the values `177 Wear Range Delta`, `231 Life Left (SSDs)` and `233 Media Wearout Indicator` are typically read as normalized numbers rather than interpreting their raw numbers.

While the raw value 177 defines the delta between most-worn and least-worn Flash blocks, describing how good/bad the wear levelling of the SSD works, its normalized value is a number between 100 and 0, where 100 is the best state and 0 the worst. Having this 100-0 range is way easier to set up alert rules, compared to a value where the threshold may be manufacturer dependant.

Regarding values 231 and 233, Wikipedia describes them as normalized values, except in very old disks, in which they are also referenced in other numbers. Normalizing these values will also help set up alert rules, instead of internal manufacturer numbers.

Cheers!

Sources:
 - https://en.wikipedia.org/wiki/Self-Monitoring,_Analysis_and_Reporting_Technology
 - https://superuser.com/questions/1037644/samsung-ssd-wear-leveling-count-meaning
 - https://community.librenms.org/t/alert-rule-ssd-wearout/18673/8 (this thread shows how easy the value 177 can be badly and easily interpreted as normalized)