### PR TITLE
Update powerdns.py to use 'list' instead of 'show *'

### DIFF
--- a/snmp/powerdns.py
+++ b/snmp/powerdns.py
@@ -6,7 +6,7 @@ import subprocess
 pdnscontrol = "/usr/bin/pdns_control"
 
 process = subprocess.Popen(
-    [pdnscontrol, "show", "*"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    [pdnscontrol, "list"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
 )
 input = process.communicate()
 stdout = input[0].decode()


### PR DESCRIPTION
Using [pdnscontrol, "list"] provides the same output as [pdnscontrol, "show", "*"] but avoids some of the CLI downsides of using the '*' character in arguments.