### PR TITLE
Add HTTPS with CA file and Authorization header from file for opensearch script

### DIFF
--- a/snmp/opensearch
+++ b/snmp/opensearch
@@ -31,11 +31,14 @@ Add this to snmpd.conf as below and restart snmpd.
 
 Supported command line options are as below.
 
+    -c <path>   CA file path.
+                Default: empty
     -h <host>   The host to connect to.
                 Default: 127.0.0.1
     -p <port>   The port to use.
                 Default: 9200
     -P          Pretty print.
+    -S          Use HTTPS.
 
 The last is only really relevant to the usage with SNMP.
 
@@ -55,24 +58,30 @@ sub main::VERSION_MESSAGE {
 
 sub main::HELP_MESSAGE {
 	print "\n"
+		. "-c <path>   CA file path.\n"
 		. "-h <host>   The host to connect to.\n"
 		. "            Default: 127.0.0.1\n"
 		. "-p <port>   The port to use.\n"
 		. "            Default: 9200\n"
-		. "-P          Pretty print.\n";
+		. "-P          Pretty print.\n"
+		. "-S          Use HTTPS.\n";
 }
 
 my $host = '127.0.0.1';
 my $port = 9200;
+my $schema = 'http';
 
 #gets the options
 my %opts;
-getopts( 'h:p:P', \%opts );
+getopts( 'c:h:p:P:S', \%opts );
 if ( defined( $opts{h} ) ) {
 	$host = $opts{h};
 }
 if ( defined( $opts{p} ) ) {
 	$port = $opts{p};
+}
+if ( $opts{S} ) {
+	$schema = 'https';
 }
 
 #
@@ -83,8 +92,8 @@ my $to_return = {
 	date        => {},
 };
 
-my $stats_url  = 'http://' . $host . ':' . $port . '/_stats';
-my $health_url = 'http://' . $host . ':' . $port . '/_cluster/health';
+my $stats_url  = $schema . '://' . $host . ':' . $port . '/_stats';
+my $health_url = $schema . '://' . $host . ':' . $port . '/_cluster/health';
 
 my $json = JSON->new->allow_nonref->canonical(1);
 if ( $opts{P} ) {
@@ -92,6 +101,11 @@ if ( $opts{P} ) {
 }
 
 my $ua = LWP::UserAgent->new( timeout => 10 );
+
+if ( defined( $opts{c} ) ) {
+	# set ca file
+	$ua->ssl_opts( SSL_ca_file => $opts{c});
+}
 
 my $stats_response = $ua->get($stats_url);
 my $stats_json;

--- a/snmp/opensearch
+++ b/snmp/opensearch
@@ -31,6 +31,7 @@ Add this to snmpd.conf as below and restart snmpd.
 
 Supported command line options are as below.
 
+    -a <path>   Auth token path.
     -c <path>   CA file path.
                 Default: empty
     -h <host>   The host to connect to.
@@ -58,6 +59,7 @@ sub main::VERSION_MESSAGE {
 
 sub main::HELP_MESSAGE {
 	print "\n"
+		. "-a <path>   Auth token path.\n"
 		. "-c <path>   CA file path.\n"
 		. "-h <host>   The host to connect to.\n"
 		. "            Default: 127.0.0.1\n"
@@ -73,7 +75,7 @@ my $schema = 'http';
 
 #gets the options
 my %opts;
-getopts( 'c:h:p:P:S', \%opts );
+getopts( 'a:c:h:p:P:S', \%opts );
 if ( defined( $opts{h} ) ) {
 	$host = $opts{h};
 }
@@ -82,6 +84,14 @@ if ( defined( $opts{p} ) ) {
 }
 if ( $opts{S} ) {
 	$schema = 'https';
+}
+
+my $auth_token;
+if ( defined( $opts{a} ) ) {
+	open my $auth_file, '<', $opts{a};
+	$auth_token = <$auth_file>;
+	close $auth_file;
+	chop $auth_token;
 }
 
 #
@@ -107,7 +117,13 @@ if ( defined( $opts{c} ) ) {
 	$ua->ssl_opts( SSL_ca_file => $opts{c});
 }
 
-my $stats_response = $ua->get($stats_url);
+my $stats_response;
+if ( defined( $opts{a} ) ) {
+	$stats_response = $ua->get($stats_url, "Authorization" => $auth_token,);
+} else {
+	$stats_response = $ua->get($stats_url);
+}
+
 my $stats_json;
 if ( $stats_response->is_success ) {
 	eval { $stats_json = decode_json( $stats_response->decoded_content ); };
@@ -131,7 +147,13 @@ else {
 	exit;
 }
 
-my $health_response = $ua->get($health_url);
+my $health_response;
+if ( defined( $opts{a} ) ) {
+	$health_response = $ua->get($health_url, "Authorization" => $auth_token,);
+} else {
+	$health_response = $ua->get($health_url);
+}
+
 my $health_json;
 if ( $health_response->is_success ) {
 	eval { $health_json = decode_json( $health_response->decoded_content ); };


### PR DESCRIPTION
Features:
- HTTPS
- HTTPS certificate validation with CA file
- Authorization header in request from file

Options added:
- -a <path>   Auth token path
- -c <path>   CA file path
- -S          Use HTTPS

Example:
./opensearch -h 127.0.0.1 -p 9200 -S -c /etc/wazuh-indexer/certs/root-ca.pem -a creds

File creds with Authorization header Basic:
Basic <username:password base64 encoded>

Example creds:
Basic YWRtaW46cGFzc3dvcmQ=

Tested with wazuh-indexer 4.7.3-1 on Debian 12.5
