### PR TITLE
ignore inactive arrays for now

### DIFF
--- a/snmp/mdadm
+++ b/snmp/mdadm
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # MDADM SNMP extension for LibreNMS
 # Version
-extendVer='2.0.0'
+extendVer='2'
 # Initial portion of json
 mdadmSNMPOutput='{ "data": ['
 
@@ -40,6 +40,10 @@ main() {
             [[ "${mdadmArray}" =~ '/dev/md'[[:digit:]]+'p' ]] && continue
 
             mdadmName="$(basename "$(realpath "${mdadmArray}")")"
+
+			# Ignore inactive arrays
+			[[ $(grep "^${mdadmName}" /proc/mdstat) =~ 'inactive' ]] && continue
+
             mdadmSysDev="/sys/block/${mdadmName}"
 
             degraded=$(maybe_get "${mdadmSysDev}/md/degraded")


### PR DESCRIPTION
Ignore inactive arrays as per https://github.com/librenms/librenms-agent/issues/521 .

Properly fixing this is going to involve a re-write of the extend and updating the polling so that `.data` is not an array.