### PR TITLE
Pi-hole v6 API changes

### DIFF
--- a/snmp/pi-hole
+++ b/snmp/pi-hole
@@ -5,9 +5,8 @@ IFS=$'\n\t'
 CONFIGFILE='/etc/snmp/pi-hole.conf'
 
 API_AUTH_KEY=""
-API_URL="localhost/admin/api.php"
-URL_READ_ONLY="?summaryRaw&auth="
-URL_QUERY_TYPE="?getQueryTypes&auth="
+API_URL="localhost/api"
+URL_READ_ONLY="/stats/summary"
 PICONFIGFILE='/etc/pihole/setupVars.conf'
 DHCPLEASEFILE='/etc/pihole/dhcp.leases'
 
@@ -69,11 +68,6 @@ debug() {
 		echo '[ok] URL_READ_ONLY is set'
 	fi
 
-	if [ -z "${URL_QUERY_TYPE}" ]; then
-		echo '[error] URL_QUERY_TYPE is not set'
-	else
-		echo '[ok] URL_QUERY_TYPE not set'
-	fi
 	if [ -f $PICONFIGFILE ]; then
 		echo '[ok] Pi-Hole config file exists, DHCP stats will be captured if scope active'
 	else
@@ -88,12 +82,9 @@ debug() {
 
 exportdata() {
 	# domains_being_blocked / dns_query_total / ads_blocked_today / ads_percentage_today
-	# unique_domains / queries_forwarded / queries_cached
-	GET_STATS=$(curl -s "${API_URL}${URL_READ_ONLY}${API_AUTH_KEY}" | jq '.domains_being_blocked, .dns_queries_today, .ads_blocked_today, .ads_percentage_today, .unique_domains, .queries_forwarded, .queries_cached')
+	# unique_domains / queries_forwarded / queries_cached / A / AAAA / PTR / SRV
+	GET_STATS=$(curl -s "${API_URL}${URL_READ_ONLY}${API_AUTH_KEY}" | jq '.gravity.domains_being_blocked, .queries.total, .queries.blocked, .queries.percent_blocked, .queries.unique_domains, .queries.forwarded, .queries.cached, .queries.types.A, .queries.types.AAAA, .queries.types.PTR, .queries.types.SRV')
 	echo "$GET_STATS" | tr " " "\n"
-	# A / AAAA / PTR / SRV
-	GET_QUERY_TYPE=$(curl -s "${API_URL}${URL_QUERY_TYPE}${API_AUTH_KEY}" | jq '.[]["A (IPv4)", "AAAA (IPv6)", "PTR", "SRV"]')
-	echo "$GET_QUERY_TYPE" | tr " " "\n"
 
 	# Find number of DHCP address in scope and current lease count
 	# case-insensitive compare, just in case :)


### PR DESCRIPTION
This is getting my stats working with v6.

I *did not* test or fix DHCP since I don't use it, and if you have an API key their endpoint requires you to get a token, so that's not working either.

I didn't think to look at the v5 API before I upgraded my instances, but it looks like it must have been outputting query types in thousands. My numbers all jumped from like ~55 to ~55,000 but they're all proportionally correct. And all of the rest of the graphs seem to be the same.