### PR TITLE
fix agent-local-rpm No such file or directory (OpenSUSE)

### DIFF
--- a/agent-local/rpm
+++ b/agent-local/rpm
@@ -3,6 +3,11 @@
 # If you want to override this, put the command in cron.
 # We cache because it is a 1sec delay, which is painful for the poller
 if [ -x /bin/rpm ]; then
+
+  CACHE_DIR="/var/cache/librenms"
+  FILE="$CACHE_DIR/agent-local-rpm"
+  mkdir -p $CACHE_DIR
+
   DATE=$(date +%s)
   FILE=/var/cache/librenms/agent-local-rpm
   if [ ! -e $FILE ]; then


### PR DESCRIPTION
Improvement of the problem that rpm pkgs of opensuse cannot be checked