### PR TITLE
skip empty lines returned by iwinfo in wlNoiseFloor.sh

### DIFF
--- a/snmp/Openwrt/wlNoiseFloor.sh
+++ b/snmp/Openwrt/wlNoiseFloor.sh
@@ -13,7 +13,7 @@ fi
 
 # Extract noise floor. Note, all associated stations have the same value, so just grab the first one
 # Use tail, not head (i.e. last line, not first), as head exits immediately, breaks the pipe to cut!
-noise=$(/usr/bin/iwinfo "$1" assoclist 2>/dev/null | /usr/bin/cut -s -d "/" -f 2 | /usr/bin/cut -s -d "(" -f 1 | /usr/bin/cut -s -d " " -f 2 | /usr/bin/tail -1)
+noise=$(/usr/bin/iwinfo "$1" assoclist 2>/dev/null | grep -v "^$" | /usr/bin/cut -s -d "/" -f 2 | /usr/bin/cut -s -d "(" -f 1 | /usr/bin/cut -s -d " " -f 2 | /usr/bin/tail -1)
 
 # Return snmp result
 /bin/echo "$noise"


### PR DESCRIPTION
Sometime after Openwrt 19.07 the `iwinfo` application adds an empty line after each node's information. This breaks `wlNoiseFloor.sh` This commit removes the empty lines to restore functionality