### PR TITLE
Update ss.py

### DIFF
--- a/snmp/ss.py
+++ b/snmp/ss.py
@@ -3,7 +3,7 @@
 # Name: Socket Statistics Script
 # Author: bnerickson <bnerickson87@gmail.com> w/SourceDoctor's certificate.py script forming
 #         the base of the vast majority of this one.
-# Version: 1.0
+# Version: 1.1
 # Description: This is a simple script to parse "ss" output for ingestion into
 #              LibreNMS via the ss application.
 # Installation:
@@ -50,11 +50,14 @@
 #         ```
 #     4. Restart snmpd and activate the app for desired host.
 
+import argparse
 import json
 import subprocess
 import sys
 
-CONFIG_FILE = "/etc/snmp/ss.json"
+
+DEFAULT_CONFIG_FILE = "/etc/snmp/ss.json"
+
 SOCKET_MAPPINGS = {
     "dccp": {
         "args": ["--dccp"],
@@ -177,7 +180,14 @@ def error_handler(error_name, err):
     sys.exit(1)
 
 
-def config_file_parser():
+def parse_args():
+    parser = argparse.ArgumentParser(description="Socket Statistics Script for LibreNMS")
+    parser.add_argument('-r', '--config', default=DEFAULT_CONFIG_FILE,
+                        help="Path to configuration JSON file (default: /etc/snmp/ss.json)")
+    return parser.parse_args()
+
+
+def config_file_parser(config_path):
     """
     config_file_parser(): Parses the config file (if it exists) and extracts the
                           necessary parameters.
@@ -194,7 +204,7 @@ def config_file_parser():
 
     # Load configuration file if it exists
     try:
-        with open(CONFIG_FILE, "r", encoding="utf-8") as json_file:
+        with open(config_path, "r", encoding="utf-8") as json_file:
             config_file = json.load(json_file)
             ss_cmd = [config_file["ss_cmd"]]
             socket_allow_list_clean = list(
@@ -331,8 +341,9 @@ def main():
     output_data = {"errorString": "", "error": 0, "version": 1, "data": {}}
 
     # Parse configuration file.
-    ss_cmd, socket_allow_list, addr_family_allow_list = config_file_parser()
-
+    args = parse_args()
+    ss_cmd, socket_allow_list, addr_family_allow_list = config_file_parser(args.config)
+    
     # Execute ss command for socket types.
     for gentype in list(SOCKET_MAPPINGS.keys()):
         # Skip socket types and address families disabled by the user.


### PR DESCRIPTION

- Introduced argparse to support '-r' or '--config' command-line option for specifying the configuration JSON file path.
- The default config path remains /etc/snmp/ss.json for backward compatibility.
- This enhancement allows users to flexibly provide alternative config files without modifying the script.
- Updated internal logic to consistently use the supplied config path.