### PR TITLE
Catch mysqli exceptions

### DIFF
--- a/agent-local/mysql
+++ b/agent-local/mysql
@@ -1322,6 +1322,12 @@ function run_query($sql, $conn) {
          die("SQLERR $error in $sql");
       }
    }
+
+   if ( is_null( $result ) ) {
+      debug('No result for query: ' . $sql);
+      return;
+   }
+
    $array = array();
    $count = @mysqli_num_rows($result);
    if ( $count > 10000 ) {

--- a/agent-local/mysql
+++ b/agent-local/mysql
@@ -1311,7 +1311,7 @@ function run_query($sql, $conn) {
    {
       if ( $debug )
       {
-         debug( $e->getMessages() );
+         debug('Caught mysqli exception: ' . $e->getMessages());
       }
    }
 

--- a/agent-local/mysql
+++ b/agent-local/mysql
@@ -1304,7 +1304,17 @@ function to_int ( $str ) {
 function run_query($sql, $conn) {
    global $debug;
    debug($sql);
-   $result = @mysqli_query($conn, $sql);
+   try {
+      $result = @mysqli_query($conn, $sql);
+   }
+   catch ( Exception $e )
+   {
+      if ( $debug )
+      {
+         debug( $e->getMessages() );
+      }
+   }
+
    if ( $debug && strpos($sql, 'SHOW SLAVE STATUS ') === false ) {
       $error = @mysqli_error($conn);
       if ( $error ) {


### PR DESCRIPTION
Fixes #574

According to https://www.php.net/manual/en/mysqli-driver.report-mode.php, the default value for  `mysqli_report` changes in PHP 8.1.0 to `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT`, which results in the exception thrown described in #574.

There are already alternate queries for obtaining the `SLAVE STATUS`, but without catching the exception, these are never reached. 

This has been tested with php 8.2.28 (cli) against a MariaDB 10.5.27 DB.