### PR TITLE
read battery.temperature or ups.temperature

### DIFF
--- a/snmp/ups-nut.sh
+++ b/snmp/ups-nut.sh
@@ -39,7 +39,7 @@ do
     fi
 done
 
-UPSTEMP="ups\.temperature: [0-9.]+"
+UPSTEMP="^(battery|ups)\.temperature: [0-9.]+"
 OUT=$(echo "$TMP" | grep -Eo "$UPSTEMP" | awk '{print $2}' | LANG=C sort | head -n 1)
 [ -n "$OUT" ] && echo "$OUT" || echo "Unknown"
 


### PR DESCRIPTION
I have two UPSs from APC. One reports battery.temperature the other ups.temperature. This small fix should fix to get a temperature reading.