### PR TITLE
hddtemp2: check if disk is a valid device and fix model name for smartctl

### DIFF
--- a/agent-local/hddtemp2
+++ b/agent-local/hddtemp2
@@ -29,7 +29,7 @@ if [ "${smartctl}" != "" ]; then
                 # Check if the disk is a valid device
                 if ${smartctl} -i "$disk" > /dev/null 2>&1; then
                     # Get disk model first
-                    model=$(${smartctl} -i $disk | grep 'Device Model' | cut -d':' -f2 | sed 's/^\s*//g')
+                    model=$(${smartctl} -i $disk | grep 'Device Model' | cut -d':' -f2 | tr -d '[:space:]$')
 
                     # Try different temperature attributes in order of preference
                     # First try Airflow_Temperature_Cel

--- a/agent-local/hddtemp2
+++ b/agent-local/hddtemp2
@@ -3,7 +3,7 @@
 # Name: hddtemp2
 # Author: Jason Cheng (www.jason.tools)
 # Date: 2025-02-17
-# Version: 1.1
+# Version: 1.2
 # Purpose: This script replaces the obsolete hddtemp tool for librenms agent to monitor disk temperatures
 # License: Free Software
 
@@ -26,25 +26,28 @@ if [ "${smartctl}" != "" ]; then
         for disk in $disks; do
             # Exclude non-physical disks like RBD (RADOS Block Device)
             if [[ ! "$disk" =~ rbd ]]; then
-                # Get disk model first
-                model=$(${smartctl} -i $disk | grep 'Device Model' | cut -d':' -f2 | sed 's/^\s*//g')
-                
-                # Try different temperature attributes in order of preference
-                # First try Airflow_Temperature_Cel
-                temp_info=$(${smartctl} -A $disk | grep 'Airflow_Temperature_Cel' | awk '{print $10}')
+                # Check if the disk is a valid device
+                if ${smartctl} -i "$disk" > /dev/null 2>&1; then
+                    # Get disk model first
+                    model=$(${smartctl} -i $disk | grep 'Device Model' | cut -d':' -f2 | sed 's/^\s*//g')
 
-                # If not found, try Temperature_Celsius
-                if [ -z "$temp_info" ]; then
-                    temp_info=$(${smartctl} -A $disk | grep 'Temperature_Celsius' | awk '{print $10}')
+                    # Try different temperature attributes in order of preference
+                    # First try Airflow_Temperature_Cel
+                    temp_info=$(${smartctl} -A $disk | grep 'Airflow_Temperature_Cel' | awk '{print $10}')
+
+                    # If not found, try Temperature_Celsius
+                    if [ -z "$temp_info" ]; then
+                        temp_info=$(${smartctl} -A $disk | grep 'Temperature_Celsius' | awk '{print $10}')
+                    fi
+
+                    # If still not found, try Drive_Temperature
+                    if [ -z "$temp_info" ]; then
+                        temp_info=$(${smartctl} -A $disk | grep 'Drive_Temperature' | awk '{print $4}')
+                    fi
+
+                    # Format output regardless of which temperature was found
+                    output="${output}|${disk}|${model}|${temp_info}|C|"
                 fi
-
-                # If still not found, try Drive_Temperature
-                if [ -z "$temp_info" ]; then
-                    temp_info=$(${smartctl} -A $disk | grep 'Drive_Temperature' | awk '{print $4}')
-                fi
-
-                # Format output regardless of which temperature was found
-                output="${output}|${disk}|${model}|${temp_info}|C|"
             fi
         done
         # Clean output, keep only printable characters


### PR DESCRIPTION
This PR includes two changes:

___

First one to check if disk is a valid device. In one case I have, `smartctl -i /dev/zd336` fails and returns:

```
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.8.12-13-pve] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

/dev/zd96: Unable to detect device type
Please specify device type with the -d option.

Use smartctl -h to get a usage summary
```

We should check if smartctl succeeds.

___

And last one strips spaces for model name returned otherwise the poller fails to parse hddtemp from unix_agent module:

```
#### Load poller module unix-agent ####
  
LibreNMS UNIX Agent: execution time: 705ms
hddtemp: 
Processes: 
Sensors: -/dev/nvme0n1: SamsungSSD970PRO512GB: Cur 34, Low: 24, Low Warn: , Warn: , High: 54  
+25 °C  
25 °C  
25 °C  
25 °C  
Exception: ValueError "0" is not a valid backing value for enum LibreNMS\Enum\Sensor @ /opt/librenms/includes/polling/functions.inc.php:140
#0 /opt/librenms/includes/polling/functions.inc.php(140): LibreNMS\Enum\Sensor::from()
#1 /opt/librenms/includes/polling/unix-agent.inc.php(215): record_sensor_data()
#2 /opt/librenms/LibreNMS/Modules/LegacyModule.php(112): include('...')
#3 /opt/librenms/app/Jobs/PollDevice.php(139): LibreNMS\Modules\LegacyModule->poll()
#4 /opt/librenms/app/Jobs/PollDevice.php(63): App\Jobs\PollDevice->pollModules()
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Jobs\PollDevice->handle()
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#7 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(96): Illuminate\Container\Util::unwrapIfClosure()
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod()
#9 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(754): Illuminate\Container\BoundMethod::call()
#10 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(132): Illuminate\Container\Container->call()
#11 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(169): Illuminate\Bus\Dispatcher->Illuminate\Bus\{closure}()
#12 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(126): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#13 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(136): Illuminate\Pipeline\Pipeline->then()
#14 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(125): Illuminate\Bus\Dispatcher->dispatchNow()
#15 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(169): Illuminate\Queue\CallQueuedHandler->Illuminate\Queue\{closure}()
#16 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(126): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#17 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(120): Illuminate\Pipeline\Pipeline->then()
#18 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(68): Illuminate\Queue\CallQueuedHandler->dispatchThroughMiddleware()
#19 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php(102): Illuminate\Queue\CallQueuedHandler->call()
#20 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php(130): Illuminate\Queue\Jobs\Job->fire()
#21 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php(110): Illuminate\Queue\SyncQueue->executeJob()
#22 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(250): Illuminate\Queue\SyncQueue->push()
#23 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(234): Illuminate\Bus\Dispatcher->pushCommandToQueue()
#24 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(101): Illuminate\Bus\Dispatcher->dispatchToQueue()
#25 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Bus/Dispatchable.php(76): Illuminate\Bus\Dispatcher->dispatchSync()
#26 /opt/librenms/app/Console/Commands/DevicePoll.php(79): App\Jobs\PollDevice::dispatchSync()
#27 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Console\Commands\DevicePoll->handle()
#28 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#29 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(96): Illuminate\Container\Util::unwrapIfClosure()
#30 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod()
#31 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(754): Illuminate\Container\BoundMethod::call()
#32 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(209): Illuminate\Container\Container->call()
#33 /opt/librenms/vendor/symfony/console/Command/Command.php(318): Illuminate\Console\Command->execute()
#34 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(178): Symfony\Component\Console\Command\Command->run()
#35 /opt/librenms/vendor/symfony/console/Application.php(1092): Illuminate\Console\Command->run()
#36 /opt/librenms/vendor/symfony/console/Application.php(341): Symfony\Component\Console\Application->doRunCommand()
#37 /opt/librenms/vendor/symfony/console/Application.php(192): Symfony\Component\Console\Application->doRun()
#38 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(197): Symfony\Component\Console\Application->run()
#39 /opt/librenms/lnms(37): Illuminate\Foundation\Console\Kernel->handle()
#40 {main}
```

For example it currently returns:

```
|/dev/sda|Samsung SSD 870 QVO 4TB|25|C|
```

But should be:

```
|/dev/sda|SamsungSSD870QVO4TB|25|C|
```

cc @jasoncheng7115