### PR TITLE
agent-local/proxmox: remove unused TIMEZONE constant

### DIFF
--- a/agent-local/proxmox
+++ b/agent-local/proxmox
@@ -14,10 +14,6 @@
 #
 # See http://www.gnu.org/licenses/gpl.txt for the full license
 
-use constant {
-    TIMEZONE => 'Europe/Amsterdam'
-};
-
 use strict;
 use PVE::APIClient::LWP;
 use PVE::AccessControl;


### PR DESCRIPTION
## Summary

The `TIMEZONE` constant (`'Europe/Amsterdam'`) was introduced in the initial commit (2015) but has never been referenced anywhere in the script, nor is it parsed or used by the LibreNMS application.

- The constant is defined but never called within `agent-local/proxmox`
- The LibreNMS pollers (`includes/polling/applications/proxmox.inc.php` et al.) do not extract or act on a timezone value from the agent output
- No documentation mentions timezone as a configurable option for this plugin

Removing it eliminates confusion for users outside Europe/Amsterdam who may wonder whether the value is affecting their data, or spend time trying to update it.

## Change

Remove the four dead-code lines:

```perl
use constant {
    TIMEZONE => 'Europe/Amsterdam'
};
```