### PR TITLE
Extend scripts for snmpd for hardware, manufacturer, and serial

### DIFF
--- a/snmp/hardware
+++ b/snmp/hardware
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# Detects which hardware.
+
+if [ -r /sys/devices/virtual/dmi/id/product_name ]; then
+  DMI=$(cat /sys/devices/virtual/dmi/id/product_name)
+fi
+if [ -r /sys/firmware/devicetree/base/model ]; then
+  DT=$(cat /sys/firmware/devicetree/base/model)
+fi
+
+if [ -n "${DMI}" ]; then
+  if [ "${DMI}" != "To Be Filled By O.E.M." ] && [ "${DMI}" != "Default string" ] && [ "${DMI}" != "Not Specified" ] && [ "${DMI}" != "None" ] ; then
+    HARDWARESTR="${DMI}"
+  fi
+fi
+if [ -z "${HARDWARESTR}" ] && [ -n "${DT}" ]; then
+  HARDWARESTR="${DT}"
+fi
+  
+echo "${HARDWARESTR}"

--- a/snmp/manufacturer
+++ b/snmp/manufacturer
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# Detects which manufacturer.
+
+if [ -r /sys/devices/virtual/dmi/id/sys_vendor ]; then
+  DMI=$(cat /sys/devices/virtual/dmi/id/sys_vendor)
+fi
+
+if [ -n "${DMI}" ]; then
+  if [ "${DMI}" != "To Be Filled By O.E.M." ] && [ "${DMI}" != "Default string" ] && [ "${DMI}" != "Not Specified" ] && [ "${DMI}" != "None" ] ; then
+    MANUFACTURERSTR="${DMI}"
+  fi
+fi
+  
+echo "${MANUFACTURERSTR}"

--- a/snmp/serial
+++ b/snmp/serial
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# Detects which serial.
+
+if [ -r /sys/devices/virtual/dmi/id/product_serial ]; then
+  DMI=$(cat /sys/devices/virtual/dmi/id/product_serial)
+fi
+if [ -r /sys/firmware/devicetree/base/serial-number ]; then
+  DT=$(cat /sys/firmware/devicetree/base/serial-number)
+fi
+
+if [ -n "${DMI}" ]; then
+  if [ "${DMI}" != "To Be Filled By O.E.M." ] && [ "${DMI}" != "Default string" ] && [ "${DMI}" != "Not Specified" ] && [ "${DMI}" != "None" ] ; then
+    SERIALSTR="${DMI}"
+  fi
+fi
+if [ -z "${SERIALSTR}" ] && [ -n "${DT}" ]; then
+  SERIALSTR="${DT}"
+fi
+  
+echo "${SERIALSTR}"


### PR DESCRIPTION
Currently the docs say to do this on x86...

```
extend distro /usr/bin/distro
extend hardware '/bin/cat /sys/devices/virtual/dmi/id/product_name'
extend manufacturer '/bin/cat /sys/devices/virtual/dmi/id/sys_vendor'
extend serial '/bin/cat /sys/devices/virtual/dmi/id/product_serial'

```
Or this on ARM...

```
extend distro /usr/bin/distro
extend hardware '/bin/cat /sys/firmware/devicetree/base/model'
extend serial '/bin/cat /sys/firmware/devicetree/base/serial-number'
```

But if you weren't paying attention much on ARM you might miss this... and perhaps it's better not to hard code such things like this into the config file itself?

Ultimately the docs already say to download 'distro' from this repo, so what's a few more which can be downloaded at the same time?... these extra scripts have also been written in the same coding style as 'distro' (so if it looks a bit clunky, look elsewhere!) to match it.

My thinking is... using a script which people can easily update might be easier if the way things are determined needs to be updated in the future (with lots of different platforms and CPU architectures)... as people can just update the scripts like they do with the new distributions that come out.

Plus it can do other things like filter out dummy strings.  Also I'm not sure, but I've read that devicetree terminates its strings with null bytes? and sometimes this can be an issue with SNMP clients?  Perhaps it's not an issue for LibreNMS... but it's that kind of thing we can accommodate for in a script... which is just a bit too unwieldy as a "one liner" in snmpd.conf

Thoughts welcome... I'm not married to this.