### PR TITLE
Adjust parsing of 'proto' to allow for "HTTP/2.0"

### DIFF
--- a/snmp/http_access_log_combined
+++ b/snmp/http_access_log_combined
@@ -573,10 +573,10 @@ foreach my $log_name ( keys( %{ $config->{access} } ) ) {
 				} elsif ( $parsed->{proto} eq 'HTTP/1.1' ) {
 					$new_entry->{'http1_1'}++;
 					$data->{totals}{'http1_1'}++;
-				} elsif ( $parsed->{proto} eq 'HTTP/2' ) {
+				} elsif ( index( $parsed->{proto}, 'HTTP/2' ) != -1 ) {
 					$new_entry->{'http2'}++;
 					$data->{totals}{'http2'}++;
-				} elsif ( $parsed->{proto} eq 'HTTP/3' ) {
+				} elsif ( index( $parsed->{proto}, 'HTTP/3' ) != -1 ) {
 					$new_entry->{'http3'}++;
 					$data->{totals}{'http3'}++;
 				}


### PR DESCRIPTION
In the standard Apache/nginx combined log format http2 request are logged as "HTTP/2.0" (tested with nginx), which "eq" does _not_ catch. This change checks if "proto" _contains_ "HTTP/2" or "HTTP/3".