### PR TITLE
gpsd: scan all SKY frames for richest snapshot, use single-pass parse

### DIFF
--- a/snmp/gpsd
+++ b/snmp/gpsd
@@ -14,7 +14,7 @@
 BIN_GPIPE='/usr/bin/env gpspipe'
 BIN_GREP='/usr/bin/env grep'
 BIN_PYTHON='/usr/bin/env python3'
-LINES=20
+LINES=50
 
 # Check for config file
 CONFIG=$0".conf"
@@ -30,16 +30,65 @@ trap 'rm -f $TMPFILE' 0 2 3 15
 # Write GPSPIPE Data to Temp File
 $BIN_GPIPE -w -n $LINES > "$TMPFILE"
 
-# Parse Temp file for GPSD Data
-VERSION=$(cat "$TMPFILE" | $BIN_GREP -m 1 "VERSION" | $BIN_PYTHON -c 'import sys,json;print(json.load(sys.stdin)["rev"])' 2> /dev/null)
-GPSDMODE=$(cat "$TMPFILE" | $BIN_GREP -m 1 "TPV" | $BIN_PYTHON -c 'import sys,json;print(json.load(sys.stdin)["mode"])' 2> /dev/null)
-HDOP=$(cat "$TMPFILE" | $BIN_GREP -m 1 "SKY" | $BIN_PYTHON -c 'import sys,json;print(json.load(sys.stdin)["hdop"])' 2> /dev/null)
-VDOP=$(cat "$TMPFILE" | $BIN_GREP -m 1 "SKY" | $BIN_PYTHON -c 'import sys,json;print(json.load(sys.stdin)["vdop"])' 2> /dev/null)
-LAT=$(cat "$TMPFILE" | $BIN_GREP -m 1 "TPV" | $BIN_PYTHON -c 'import sys,json;print(json.load(sys.stdin)["lat"])' 2> /dev/null)
-LONG=$(cat "$TMPFILE" | $BIN_GREP -m 1 "TPV" | $BIN_PYTHON -c 'import sys,json;print(json.load(sys.stdin)["lon"])' 2> /dev/null)
-ALT=$(cat "$TMPFILE" | $BIN_GREP -m 1 "TPV" | $BIN_PYTHON -c 'import sys,json;print(json.load(sys.stdin)["alt"])' 2> /dev/null)
-SATS=$(cat "$TMPFILE" | $BIN_GREP -m 1 "SKY" | $BIN_PYTHON -c 'import sys,json;print(len(json.load(sys.stdin)["satellites"]))' 2> /dev/null)
-SATSUSED=$(cat "$TMPFILE" | $BIN_GREP -m 1 "SKY" | $BIN_PYTHON -c 'import sys,json;print(len([sat for sat in json.load(sys.stdin)["satellites"] if sat["used"]]))' 2> /dev/null)
+# Parse data using a single Python pass that scans the whole buffer:
+# - latest TPV for mode/lat/lon/alt
+# - the "richest" SKY (highest satellites count) for hdop/vdop/sats counts
+# - this works around multi-constellation receivers (e.g. Quectel LC29H)
+#   that emit several DOP-only SKY frames between fuller accumulated ones.
+VALUES=$(cat "$TMPFILE" | $BIN_PYTHON -c '
+import sys, json
+
+best_sky = None
+best_score = -1
+last_tpv = None
+version = None
+
+for line in sys.stdin:
+    try:
+        d = json.loads(line)
+    except ValueError:
+        continue
+    cls = d.get("class")
+    if cls == "VERSION":
+        version = d.get("rev", "")
+    elif cls == "TPV":
+        last_tpv = d
+    elif cls == "SKY":
+        score = len(d.get("satellites", []) or [])
+        nsat = d.get("nSat")
+        usat = d.get("uSat")
+        if score == 0 and nsat is None and usat is None:
+            continue
+        # prefer SKY with the most satellites in the array; fall back to nSat/uSat
+        rank = score or (nsat or 0) or (usat or 0)
+        if rank > best_score:
+            best_score = rank
+            best_sky = d
+
+def g(d, k, default=""):
+    if d is None:
+        return default
+    v = d.get(k)
+    return default if v is None else v
+
+mode = g(last_tpv, "mode")
+lat  = g(last_tpv, "lat")
+lon  = g(last_tpv, "lon")
+alt  = g(last_tpv, "alt")
+hdop = g(best_sky, "hdop")
+vdop = g(best_sky, "vdop")
+
+sats_arr_len = len(best_sky.get("satellites", []) or []) if best_sky else 0
+nsat = (best_sky or {}).get("nSat")
+usat = (best_sky or {}).get("uSat")
+sats = sats_arr_len if sats_arr_len else (nsat if nsat is not None else 0)
+used = usat if usat is not None else len([s for s in (best_sky or {}).get("satellites", []) or [] if s.get("used")])
+
+# emit as space-separated for easy bash readout
+print("|".join(str(x) for x in [version, mode, hdop, vdop, lat, lon, alt, sats, used]))
+' 2> /dev/null)
+
+IFS='|' read -r VERSION GPSDMODE HDOP VDOP LAT LONG ALT SATS SATSUSED <<< "$VALUES"
 
 if [ -z "$SATS" ]; then
     SATS=0;


### PR DESCRIPTION
## Summary

The `snmp/gpsd` extend script returned `0/0` for `satellites`/`satellites_used` on a multi-constellation receiver (Quectel LC29H + gpsd 3.25, GPS+GLONASS+Galileo+BeiDou) on roughly 80% of polls. Investigation showed the receiver emits SKY frames in a repeating cycle:

```
SKY[0..3]  : len(satellites)=0, nSat=null, uSat=62   ← DOP-only summary
SKY[4]     : len=27, nSat=27, uSat=23                 ← GPS only
SKY[5]     : len=38                                    ← +GLONASS
SKY[6]     : len=48                                    ← +BeiDou
SKY[7]     : len=66
SKY[8]     : len=76, nSat=76, uSat=62                  ← FULL accumulated
SKY[9..12] : len=0 ... (cycle restarts)
```

Selecting a single SKY (whether the first via `grep -m 1` or the last via `tail -1`) randomly hits the empty DOP-only frame most of the time. Both approaches were unreliable on multi-constellation hardware.

## Changes

Rewrite the parse step as a **single Python pass** that:

- iterates the entire `gpspipe` buffer
- tracks the **latest** TPV frame (for `mode`/`lat`/`lon`/`alt`)
- tracks the **richest** SKY frame (highest accumulated satellite count, preferring `len(satellites)` and falling back to `nSat`/`uSat`)
- emits a pipe-delimited record consumed by bash to format the final JSON

This reduces subprocess invocations from 9 (one Python per metric) to 1 and is robust against partial / DOP-only frames.

Other changes:

- Bump `LINES` from 20 to 50 to guarantee at least one full constellation cycle is captured (LC29H cycles ~10 SKY frames).
- Tolerate missing keys via `d.get(...)` so partial frames no longer silently drop values via `2>/dev/null`.
- Prefer `uSat` summary for `satellites_used` with per-sat `used` flag count as fallback for older gpsd builds that don't expose summary fields.

## Reproduction

Before (10 consecutive runs on LC29H + gpsd 3.25):

```
sats=0/62
sats=0/62
sats=0/61
sats=0/62
sats=0/64
sats=0/64
sats=0/63
sats=0/60
... (visible always 0 because grep -m 1 SKY hit DOP-only frame)
```

After:

```
sats=75/65 mode=3 hdop=0.41
sats=75/66 mode=3 hdop=0.41
sats=75/66 mode=3 hdop=0.41
sats=75/66 mode=3 hdop=0.41
sats=75/65 mode=3 hdop=0.41
sats=75/64 mode=3 hdop=0.43
sats=75/64 mode=3 hdop=0.43
sats=75/65 mode=3 hdop=0.42
sats=75/64 mode=3 hdop=0.43
sats=75/65 mode=3 hdop=0.42
```

## Test plan

- [x] gpsd 3.25 + Quectel LC29H (GPS+GLONASS+Galileo+BeiDou) on Debian 13 Trixie aarch64: 10/10 stable readings, values agree with `cgps -s`
- [x] LibreNMS `gpsd` application polls extend OID, RRD `satellites`/`satellites_used` populate correctly
- [x] Single-receiver GPS fallback path (no `nSat`/`uSat`, populated `satellites[]`) returns the expected count
- [x] Empty buffer / no-fix edge case (TPV mode=1) returns `0/0` instead of crashing

## Note for downstream graph maxima

The LibreNMS-side `gpsd.inc.php` PHP module declares `addDataset('satellites', 'GAUGE', 0, 40)` and the same for `satellites_used`. Modern multi-constellation receivers routinely report 70–80+ satellites visible, exceeding this DS maximum and causing RRD to record `Unknown` (graphed as 0). A companion PR to `librenms/librenms` raising those maxima to 200 will be filed separately so this extend script's output is actually consumed correctly.