### PR TITLE
snmp/distro: add missing space in Solaris output

### DIFF
--- a/snmp/distro
+++ b/snmp/distro
@@ -8,7 +8,7 @@ REV=$(uname -r)
 if [ "${OS}" = "SunOS" ] ; then
   OS=Solaris
   ARCH=$(uname -p)
-  OSSTR="${OS} ${REV}(${ARCH} $(uname -v))"
+  OSSTR="${OS} ${REV} (${ARCH} $(uname -v))"
 
 elif [ "${OS}" = "AIX" ] ; then
   OSSTR="${OS} $(oslevel) ($(oslevel -r))"


### PR DESCRIPTION
The Solaris output lacks a space between `$REV` and `($ARCH`.  It was missing when the script was added in 4683c68 (Added Snmpd.conf example and distro executable, 2015-07-28).  Fix it.