### PR TITLE
Refactor memcached

### DIFF
--- a/snmp/memcached
+++ b/snmp/memcached
@@ -1,17 +1,30 @@
 #!/usr/bin/php
 <?php
 
+if (! class_exists('Memcached')) {
+    echo json_encode([
+        'data' => false,
+        'error' => 99,
+        'errorString' => 'php-memcached extension is not available, it must be installed and enabled.',
+        'version' => '1.1'
+    ]) . "\n";
+    exit;
+}
+
+$server = 'localhost';
+$port = 11211;
+
 $m = new Memcached();
-$m->addServer('localhost', 11211);
+$m->addServer($server, $port);
 
 $stats = $m->getStats();
 
-if (!isset($stats['localhost:11211'])) {
+if (! isset($stats["$server:$port"])) {
     echo json_encode([
-        'error' => 1,
-        'errorString' => 'Unable to retrieve memcached statistics',
-        'version' => '1.1',
         'data' => [],
+        'error' => $m->getLastErrorCode(),
+        'errorString' => $m->getLastErrorMessage() ?: 'Unable to retrieve memcached statistics',
+        'version' => '1.1'
     ], JSON_UNESCAPED_SLASHES) . "\n";
     exit;
 }
@@ -20,6 +33,5 @@ echo json_encode([
     'error' => 0,
     'errorString' => '',
     'version' => '1.1',
-    'data' => $stats['localhost:11211'],
+    'data' => $stats["$server:$port"],
 ], JSON_UNESCAPED_SLASHES) . "\n";
-

--- a/snmp/memcached
+++ b/snmp/memcached
@@ -1,26 +1,25 @@
 #!/usr/bin/php
 <?php
 
-if (! class_exists('Memcached')) {
-    echo json_encode(array(
-        'data' => false,
-        'error' => 99,
-        'errorString' => 'php-memcached extension is not available, it must be installed and enabled.',
-        'version' => '1.1'
-    ));
+$m = new Memcached();
+$m->addServer('localhost', 11211);
+
+$stats = $m->getStats();
+
+if (!isset($stats['localhost:11211'])) {
+    echo json_encode([
+        'error' => 1,
+        'errorString' => 'Unable to retrieve memcached statistics',
+        'version' => '1.1',
+        'data' => [],
+    ], JSON_UNESCAPED_SLASHES) . "\n";
     exit;
 }
 
-$server='localhost';
-$port=11211;
-$m = new Memcached();
-$m->addServer($server, $port);
-
-echo json_encode(array(
-    // 'data' => $m->getStats(),
-    'data' => ($m->getStats())["$server:$port"],
-    'error' => $m->getLastErrorCode(),
-    'errorString' => $m->getLastErrorMessage(),
+echo json_encode([
+    'error' => 0,
+    'errorString' => '',
     'version' => '1.1',
-));
+    'data' => $stats['localhost:11211'],
+], JSON_UNESCAPED_SLASHES) . "\n";
 


### PR DESCRIPTION
Had issues with the current version code of LibreNMS, it throws out error in handling JSON.

This was my full error trace:

```text
<<<app-memcached>>> {"localhost:11211":{"pid":3752269,"uptime":2594,"time":1786974518,"version":"1.5.22","libevent":"2.1.8-stable","pointer_size":64,"rusage_user":0.33320699999999998,"rusage_system":1.1369279999999999,"max_connections":1024,"curr_connections":9,"total_connections":1968,"rejected_connections":0,"connection_structures":59,"reserved_fds":20,"cmd_get":872,"cmd_set":3699,"cmd_flush":1,"cmd_touch":309,"cmd_meta":0,"get_hits":803,"get_misses":69,"get_expired":0,"get_flushed":0,"delete_misses":2,"delete_hits":865,"incr_misses":0,"incr_hits":0,"decr_misses":0,"decr_hits":0,"cas_misses":0,"cas_hits":0,"cas_badval":0,"touch_hits":309,"touch_misses":0,"auth_cmds":0,"auth_errors":0,"bytes_read":1007079,"bytes_written":2822312,"limit_maxbytes":67108864,"accepting_conns":1,"listen_disabled_num":0,"time_in_listen_disabled_us":0,"threads":4,"conn_yields":0,"hash_power_level":16,"hash_bytes":524288,"hash_is_expanding":0,"slab_reassign_rescues":0,"slab_reassign_chunk_rescues":0,"slab_reassign_evictions_nomem":0,"slab_reassign_inline_reclaim":0,"slab_reassign_busy_items":0,"slab_reassign_busy_deletes":0,"slab_reassign_running":0,"slabs_moved":0,"lru_crawler_running":0,"lru_crawler_starts":2295,"lru_maintainer_juggles":10988,"malloc_fails":0,"log_worker_dropped":0,"log_worker_written":0,"log_watcher_skipped":0,"log_watcher_sent":0,"bytes":230611,"curr_items":255,"total_items":1627,"slab_global_page_pool":0,"expired_unfetched":18,"evicted_unfetched":0,"evicted_active":0,"evictions":0,"reclaimed":19,"crawler_reclaimed":0,"crawler_items_checked":18,"lrutail_reflocked":12,"moves_to_cold":1123,"moves_to_warm":226,"moves_within_lru":138,"direct_reclaims":0,"lru_bumps_dropped":0}} Output post stripslashes: <<<app-memcached>>> {"localhost:11211":{"pid":3752269,"uptime":2594,"time":1786974518,"version":"1.5.22","libevent":"2.1.8-stable","pointer_size":64,"rusage_user":0.33320699999999998,"rusage_system":1.1369279999999999,"max_connections":1024,"curr_connections":9,"total_connections":1968,"rejected_connections":0,"connection_structures":59,"reserved_fds":20,"cmd_get":872,"cmd_set":3699,"cmd_flush":1,"cmd_touch":309,"cmd_meta":0,"get_hits":803,"get_misses":69,"get_expired":0,"get_flushed":0,"delete_misses":2,"delete_hits":865,"incr_misses":0,"incr_hits":0,"decr_misses":0,"decr_hits":0,"cas_misses":0,"cas_hits":0,"cas_badval":0,"touch_hits":309,"touch_misses":0,"auth_cmds":0,"auth_errors":0,"bytes_read":1007079,"bytes_written":2822312,"limit_maxbytes":67108864,"accepting_conns":1,"listen_disabled_num":0,"time_in_listen_disabled_us":0,"threads":4,"conn_yields":0,"hash_power_level":16,"hash_bytes":524288,"hash_is_expanding":0,"slab_reassign_rescues":0,"slab_reassign_chunk_rescues":0,"slab_reassign_evictions_nomem":0,"slab_reassign_inline_reclaim":0,"slab_reassign_busy_items":0,"slab_reassign_busy_deletes":0,"slab_reassign_running":0,"slabs_moved":0,"lru_crawler_running":0,"lru_crawler_starts":2295,"lru_maintainer_juggles":10988,"malloc_fails":0,"log_worker_dropped":0,"log_worker_written":0,"log_watcher_skipped":0,"log_watcher_sent":0,"bytes":230611,"curr_items":255,"total_items":1627,"slab_global_page_pool":0,"expired_unfetched":18,"evicted_unfetched":0,"evicted_active":0,"evictions":0,"reclaimed":19,"crawler_reclaimed":0,"crawler_items_checked":18,"lrutail_reflocked":12,"moves_to_cold":1123,"moves_to_warm":226,"moves_within_lru":138,"direct_reclaims":0,"lru_bumps_dropped":0}} 

memcached:ERROR: -3:Invalid JSON SQL[update applications set timestamp = NOW() where app_id = ? [269] 1.04ms]


Librenms Environment:

Version | 26.8.0-dev.122+4ab87302fa - Sun Aug 16 2026 05:50:15 GMT+0200
Database Schema | 2026_07_30_162514_add_device_refresh_config_permission (397)
Web Server | nginx/1.14.1
PHP | 8.4.24
Python | 3.6.8
Database | MariaDB 11.8.8-MariaDB
Laravel | 12.64.0
RRDtool | 1.7.2
Net-SNMP | 5.8


