### PR TITLE
Default AdGuard HTTP timeout to 1 second

### DIFF
--- a/snmp/adguard
+++ b/snmp/adguard
@@ -11,16 +11,18 @@ Configuration is read from a JSON file (default /etc/snmp/adguard.json):
         "url": "http://127.0.0.1:3000",
         "username": "admin",
         "password": "secret",
-        "timeout": 5,
+        "timeout": 1,
         "insecure": false
     }
 
 "url" is the base URL of the AdGuard Home web interface. "insecure" disables
-TLS certificate verification for https URLs. "timeout" applies to each of
-the two API calls, so the SNMP timeout must exceed 2 * timeout. The config
-file holds the web UI credentials, so restrict it to the user snmpd runs
-extend scripts as (root:Debian-snmp mode 0640 on Debian/Ubuntu, root-only
-0600 where snmpd runs as root).
+TLS certificate verification for https URLs. "timeout" is seconds per API
+call (two calls per poll). LibreNMS defaults to a 1 second SNMP timeout;
+if the API is remote or slow, run the script from cron and have snmpd cat
+the cache instead of raising the SNMP timeout. The config file holds the
+web UI credentials, so restrict it to the user snmpd runs extend scripts
+as (root:Debian-snmp mode 0640 on Debian/Ubuntu, root-only 0600 where
+snmpd runs as root).
 
 snmpd.conf entry:
 
@@ -90,7 +92,7 @@ def main():
         output({}, 1, "config error: {}".format(error))
 
     auth_header = "Basic " + base64.b64encode(credentials.encode()).decode()
-    timeout = config.get("timeout", 5)
+    timeout = config.get("timeout", 1)
     insecure = bool(config.get("insecure", False))
 
     data = {}


### PR DESCRIPTION
Follow-up to #629.

LibreNMS defaults to a 1s SNMP timeout (`snmp.timeout`). The AdGuard extend makes two HTTP calls, so a 5s per-call default will generally miss the poll if AdGuard hangs.

Drop the default to 1s. Local AdGuard answers in milliseconds. If the API is remote or slow, cache via cron and `cat` the file (documented on librenms/librenms#20339) instead of raising the SNMP timeout.